### PR TITLE
Nested cross-validation

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -49,6 +49,7 @@ julia = "1"
 DecisionTree = "7806a523-6efd-50cb-b5f6-3fa6f1930dbb"
 Distances = "b4f34e82-e78d-54a5-968a-f98e89d6e8f7"
 Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
+MLJModels = "d491faf4-2d78-11e9-2867-c94bc002c0b7"
 MultivariateStats = "6f286f6a-111f-5878-ab1e-185364afe411"
 NearestNeighbors = "b8a86587-4115-5ab1-83bc-aa920d37bbce"
 StableRNGs = "860ef19b-820b-49d6-a774-d7a799459cd3"
@@ -56,4 +57,4 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 TypedTables = "9d95f2ec-7b3d-5a63-8d20-e2491e220bb9"
 
 [targets]
-test = ["DecisionTree", "Distances", "Logging", "MultivariateStats", "NearestNeighbors", "StableRNGs", "Test", "TypedTables"]
+test = ["DecisionTree", "Distances", "Logging", "MLJModels", "MultivariateStats", "NearestNeighbors", "StableRNGs", "Test", "TypedTables"]

--- a/src/MLJBase.jl
+++ b/src/MLJBase.jl
@@ -169,6 +169,7 @@ export  DeterministicNetwork, ProbabilisticNetwork, UnsupervisedNetwork
 # resampling.jl:
 export ResamplingStrategy, Holdout, CV, StratifiedCV, TimeSeriesCV,
        evaluate!, Resampler, PerformanceEvaluation
+export nested_cv
 
 # -------------------------------------------------------------------
 # exports from MLJBase specific to Measure (these may go in their

--- a/src/resampling.jl
+++ b/src/resampling.jl
@@ -193,7 +193,7 @@ In the inner loop, the `measure` is used to select the best performing
 model via the `best_measure_selector`.
 In the outer loop, the performance of the best model is estimated on the test set.
 This gives an indication of the best model and it's performance.
-Returns a dictionary which indicates the accuracy for each winning model.
+Returns a dictionary which indicates the accuracy for each winning model `i` where `i` is the index in `models`.
 
 ## TODO
 
@@ -210,7 +210,7 @@ function nested_cv(
 
     rows = 1:length(y)
     outer_folds = train_test_pairs(outer_resampling, rows)
-    results = Dict{Model,Vector}()
+    results = Dict(zip(models, fill([], length(models))))
     for (outer_train, outer_test) in outer_folds
         X_train = selectrows(X, outer_train)
         y_train = selectrows(y, outer_train)
@@ -219,9 +219,7 @@ function nested_cv(
         mach = machine(best_model, X, y)
         result = evaluate!(mach)
         measurement = result.measurement[1]
-        results[best_model] = best_model in keys(results) ?
-            append!(results[best_model], measurement) :
-            [measurement]
+        append!(results[best_model], measurement)
     end
     results
 end

--- a/src/resampling.jl
+++ b/src/resampling.jl
@@ -170,7 +170,6 @@ function train_test_pairs(cv::CV, rows)
 end
 
 function evaluate_models(
-        names::AbstractVector{String},
         M::AbstractVector{<:Model},
         X,
         y,
@@ -184,6 +183,7 @@ function evaluate_models(
     best_model_result = choose_best_result(measurements)
     # For the unlikely case that results are non-unique, take the first.
     i = findfirst(measurements .== best_model_result)
+    M[i]
 end
 
 """
@@ -201,29 +201,26 @@ Returns a dictionary which indicates the accuracy for each winning model `i` whe
 - Handle rng.
 """
 function nested_cv(
-        NamesModels::AbstractVector{Pair{String,T}},
+        M::AbstractVector{<:Model},
         X,
         y;
         outer_resampling=CV(),
         inner_resampling=CV(),
         measure=auc,
-        choose_best_result::Function=maximum) where T<:Model
+        choose_best_result::Function=maximum)
 
-    names = first.(NamesModels)
-    M = last.(NamesModels)
     rows = 1:length(y)
     outer_folds = train_test_pairs(outer_resampling, rows)
-    results = Dict(zip(names, fill([], length(names))))
+    results = Dict(zip(M, fill([], length(M))))
     for (outer_train, outer_test) in outer_folds
         X_train = selectrows(X, outer_train)
         y_train = selectrows(y, outer_train)
-        best_i = evaluate_models(names, M, X_train, y_train,
+        best_model = evaluate_models(M, X_train, y_train,
             inner_resampling, measure, choose_best_result)
-        mach = machine(M[best_i], X, y)
+        mach = machine(best_model, X, y)
         result = evaluate!(mach)
         measurement = result.measurement[1]
-        best_model_name = names[best_i]
-        results[best_model_name] = [results[best_model_name]; measurement]
+        results[best_model] = [results[best_model]; measurement]
     end
     results
 end

--- a/test/resampling.jl
+++ b/test/resampling.jl
@@ -209,20 +209,6 @@ end
     end
 end
 
-@testset "nested cross-validation" begin
-    x1 = ones(20)
-    x2 = ones(20)
-    X = (x1=x1, x2=x2)
-    y = rand(rng,20)
-
-    holdout = Holdout(fraction_train=0.75, rng=rng)
-    models = [
-        Models.DeterministicConstantRegressor(),
-        Models.DeterministicConstantRegressor()
-    ]
-    
-end
-
 @testset_accelerated "holdout" accel begin
     x1 = ones(4)
     x2 = ones(4)
@@ -378,6 +364,24 @@ end
     pairs = MLJBase.train_test_pairs(scv, 1:10N, nothing, y)
     folds = vcat(first.(pairs), last.(pairs))
     @test all([Distributions.fit(MLJBase.UnivariateFinite, y[fold]) ≈ d for fold in folds])
+end
+
+@testset "nested cross-validation" begin
+    x1 = ones(10)
+    x2 = ones(10)
+    X = (x1=x1, x2=x2)
+    y = [1.0, 1.0, 2.0, 2.0, 1.0, 1.0, 2.0, 2.0, 1.0, 1.0]
+
+    models = [
+        Models.DeterministicConstantRegressor(),
+        Models.DeterministicConstantRegressor()
+    ]
+
+    measure = rms
+    outer_resampling = CV(nfolds=2)
+    inner_resampling = CV(nfolds=2)
+    result = nested_cv(models, X, y; outer_resampling, inner_resampling, measure)
+    @test false
 end
 
 @testset_accelerated "sample weights in evaluation" accel begin

--- a/test/resampling.jl
+++ b/test/resampling.jl
@@ -367,20 +367,26 @@ end
 end
 
 @testset "nested cross-validation" begin
-    x1 = ones(10)
-    x2 = ones(10)
+    x1 = ones(20)
+    x2 = ones(20)
     X = (x1=x1, x2=x2)
-    y = [1.0, 1.0, 2.0, 2.0, 1.0, 1.0, 2.0, 2.0, 1.0, 1.0]
+    yraw = repeat([:a, :b], 10)
+    y = MLJBase.coerce(yraw, OrderedFactor{2})
 
-    models = [
-        Models.DeterministicConstantRegressor(),
-        Models.DeterministicConstantRegressor()
+    M = [
+        Models.BinaryThresholdPredictor(),
+        # Models.BinaryThresholdPredictor(threshold=0.6)
     ]
 
-    measure = rms
+    measure = accuracy
     outer_resampling = CV(nfolds=2)
     inner_resampling = CV(nfolds=2)
-    result = nested_cv(models, X, y; outer_resampling, inner_resampling, measure)
+
+    # Debug.
+    mach = machine(M[1], X, y)
+    e = evaluate!(mach, resampling=inner_resampling, measure=l1)
+
+    result = nested_cv(M, X, y; outer_resampling, inner_resampling, measure)
     @test false
 end
 

--- a/test/resampling.jl
+++ b/test/resampling.jl
@@ -374,17 +374,13 @@ end
     y = MLJBase.coerce(yraw, OrderedFactor{2})
 
     M = [
-        Models.BinaryThresholdPredictor(),
-        # Models.BinaryThresholdPredictor(threshold=0.6)
+        "first" => Models.BinaryThresholdPredictor(),
+        "second" => Models.BinaryThresholdPredictor(threshold=0.6)
     ]
 
     measure = accuracy
     outer_resampling = CV(nfolds=2)
     inner_resampling = CV(nfolds=2)
-
-    # Debug.
-    mach = machine(M[1], X, y)
-    e = evaluate!(mach, resampling=inner_resampling, measure=l1)
 
     result = nested_cv(M, X, y; outer_resampling, inner_resampling, measure)
     @test false

--- a/test/resampling.jl
+++ b/test/resampling.jl
@@ -374,8 +374,8 @@ end
     y = MLJBase.coerce(yraw, OrderedFactor{2})
 
     M = [
-        "first" => Models.BinaryThresholdPredictor(),
-        "second" => Models.BinaryThresholdPredictor(threshold=0.6)
+        MLJModels.BinaryThresholdPredictor(),
+        MLJModels.BinaryThresholdPredictor(threshold=0.6)
     ]
 
     measure = accuracy
@@ -383,7 +383,7 @@ end
     inner_resampling = CV(nfolds=2)
 
     result = nested_cv(M, X, y; outer_resampling, inner_resampling, measure)
-    @test false
+    Set(values(result)) == Set([[], [0.5, 0.5]])
 end
 
 @testset_accelerated "sample weights in evaluation" accel begin

--- a/test/resampling.jl
+++ b/test/resampling.jl
@@ -209,6 +209,20 @@ end
     end
 end
 
+@testset "nested cross-validation" begin
+    x1 = ones(20)
+    x2 = ones(20)
+    X = (x1=x1, x2=x2)
+    y = rand(rng,20)
+
+    holdout = Holdout(fraction_train=0.75, rng=rng)
+    models = [
+        Models.DeterministicConstantRegressor(),
+        Models.DeterministicConstantRegressor()
+    ]
+    
+end
+
 @testset_accelerated "holdout" accel begin
     x1 = ones(4)
     x2 = ones(4)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,8 +1,6 @@
 using Distributed
 addprocs()
 
-ENV["MLJBASE"] = true
-
 using MLJBase
 if !MLJBase.TESTING
     error("To test MLJBase, the environment variable "*
@@ -45,6 +43,67 @@ print("Loading some models for testing...")
 include_everywhere("_models/models.jl")
 print("\r                                           \r")
 
+@testset "misc" begin
+   @test include("utilities.jl")
+   @test include("static.jl")
+end
+
+@testset "interface" begin
+     @test include("interface/interface.jl")
+end
+
+@testset "univariate finite" begin
+     @test include("univariate_finite/methods.jl")
+     @test include("univariate_finite/arrays.jl")
+end
+
+@testset "measures" begin
+    @test include("measures/measures.jl")
+    @test include("measures/measure_search.jl")
+end
+
 @testset "resampling" begin
     @test include("resampling.jl")
 end
+
+@testset "data" begin
+    @test include("data/data.jl")
+    @test include("data/datasets.jl")
+    @test include("data/datasets_synthetic.jl")
+end
+
+@testset "sources" begin
+    @test include("sources.jl")
+end
+
+@testset "machines" begin
+    @test include("machines.jl")
+end
+
+@testset "composition - learning_networks" begin
+    @test include("composition/learning_networks/nodes.jl")
+    @test include("composition/learning_networks/inspection.jl")
+    @test include("composition/learning_networks/machines.jl")
+    VERSION ≥ v"1.3.0-" &&
+        @test include("composition/learning_networks/arrows.jl")
+end
+
+@testset "composition - models" begin
+    @test include("composition/models/methods.jl")
+    @test include("composition/models/from_network.jl")
+    @test include("composition/models/inspection.jl")
+    @test include("composition/models/pipelines.jl")
+    @test include("composition/models/stacking.jl")
+    @test include("composition/models/_wrapped_function.jl")
+    @test include("composition/models/static_transformers.jl")
+end
+
+@testset "operations.jl" begin
+    @test include("operations.jl")
+end
+
+@testset "hyperparam" begin
+    @test include("hyperparam/one_dimensional_ranges.jl")
+    @test include("hyperparam/one_dimensional_range_methods.jl")
+end
+

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,8 @@
 using Distributed
 addprocs()
 
+ENV["MLJBASE"] = true
+
 using MLJBase
 if !MLJBase.TESTING
     error("To test MLJBase, the environment variable "*
@@ -43,67 +45,6 @@ print("Loading some models for testing...")
 include_everywhere("_models/models.jl")
 print("\r                                           \r")
 
-@testset "misc" begin
-   @test include("utilities.jl")
-   @test include("static.jl")
-end
-
-@testset "interface" begin
-     @test include("interface/interface.jl")
-end
-
-@testset "univariate finite" begin
-     @test include("univariate_finite/methods.jl")
-     @test include("univariate_finite/arrays.jl")
-end
-
-@testset "measures" begin
-    @test include("measures/measures.jl")
-    @test include("measures/measure_search.jl")
-end
-
 @testset "resampling" begin
     @test include("resampling.jl")
 end
-
-@testset "data" begin
-    @test include("data/data.jl")
-    @test include("data/datasets.jl")
-    @test include("data/datasets_synthetic.jl")
-end
-
-@testset "sources" begin
-    @test include("sources.jl")
-end
-
-@testset "machines" begin
-    @test include("machines.jl")
-end
-
-@testset "composition - learning_networks" begin
-    @test include("composition/learning_networks/nodes.jl")
-    @test include("composition/learning_networks/inspection.jl")
-    @test include("composition/learning_networks/machines.jl")
-    VERSION ≥ v"1.3.0-" &&
-        @test include("composition/learning_networks/arrows.jl")
-end
-
-@testset "composition - models" begin
-    @test include("composition/models/methods.jl")
-    @test include("composition/models/from_network.jl")
-    @test include("composition/models/inspection.jl")
-    @test include("composition/models/pipelines.jl")
-    @test include("composition/models/stacking.jl")
-    @test include("composition/models/_wrapped_function.jl")
-    @test include("composition/models/static_transformers.jl")
-end
-
-@testset "operations.jl" begin
-    @test include("operations.jl")
-end
-
-@testset "hyperparam" begin
-    @test include("hyperparam/one_dimensional_ranges.jl")
-    @test include("hyperparam/one_dimensional_range_methods.jl")
-end
-


### PR DESCRIPTION
This PR implements nested cross-validation for different models.

For anyone also searching for nested cross-validation in MLJ, I just learned from @ablaom that it is possible to wrap a model in a `TunedModel` and `evaluate` that nested model with cross-validation.

EDIT: The reason that I think this is a good idea is because I want to compare multiple models in a paper. To people who say that you shouldn’t use nested cross-validation for model selection, I would argue that it’s better than picking the model by hand. But, now that I think of it, doing cross-validation for each model and comparing those scores is very similar except that it gives a more biased estimate for the out of sample accuracy.