### PR TITLE
Fix show for some LossFunctions measures

### DIFF
--- a/test/measures/measures.jl
+++ b/test/measures/measures.jl
@@ -73,5 +73,13 @@ include("finite.jl")
 include("loss_functions_interface.jl")
 include("confusion_matrix.jl")
 
+@testset "show method for measures" begin
+    for meta in measures()
+        m = eval(Meta.parse("$(meta.name)()"))
+        show(stdout, MIME("text/plain"), m)
+        println()
+    end
+end
+
 end
 true


### PR DESCRIPTION
Show for some LossFunctions loss functions is broken  because of the non-uniform interface for accessing the parameter of a loss from LossFunctions.jl - sometimes a field, sometimes a type parameter.

This PR addresses this issue. 