### PR TITLE
Implement `pdf(::UnivariateFinite, ::Missing) = missing` and cousins

### DIFF
--- a/src/MLJBase.jl
+++ b/src/MLJBase.jl
@@ -52,6 +52,7 @@ import LossFunctions
 import StatsBase
 import StatsBase: fit!, mode, countmap
 import Missings: levels
+using Missings
 import Distributions
 import Distributions: pdf, logpdf, sampler
 const Dist = Distributions

--- a/src/data/data.jl
+++ b/src/data/data.jl
@@ -319,7 +319,7 @@ corestrict(X, f, i) = corestrict(f, i)(X)
 ## TRANSFORMING BETWEEN CATEGORICAL ELEMENTS AND RAW VALUES
 
 _err_missing_class(c) =  throw(DomainError(
-    "Value $c not pool"))
+    "Value `$c` not in pool"))
 
 
 function transform_(pool, x)

--- a/src/univariate_finite/methods.jl
+++ b/src/univariate_finite/methods.jl
@@ -227,6 +227,7 @@ function Distributions.pdf(
     return get(d.prob_given_ref, int(cv), zero(P))
 end
 Distributions.pdf(d::UnivariateFinite{S,V}, c::V) where {S,V} = _pdf(d, c)
+Distributions.pdf(::UnivariateFinite{S,V}, ::Missing) where {S,V} = missing
 
 # Avoid method ambiguity errors with Distributions >= 0.24
 Distributions.pdf(d::UnivariateFinite{S,V}, c::V) where {S,V<:Real} = _pdf(d, c)
@@ -241,6 +242,7 @@ end
 
 Distributions.logpdf(d::UnivariateFinite, cv::CategoricalValue) = log(pdf(d,cv))
 Distributions.logpdf(d::UnivariateFinite{S,V}, c::V) where {S,V} = log(pdf(d, c))
+Distributions.logpdf(::UnivariateFinite{S,V}, ::Missing) where {S,V} = missing
 
 # Avoid method ambiguity errors with Distributions >= 0.24
 Distributions.logpdf(d::UnivariateFinite{S,V}, c::V) where {S,V<:Real} = log(pdf(d, c))

--- a/test/univariate_finite/methods.jl
+++ b/test/univariate_finite/methods.jl
@@ -27,7 +27,7 @@ A, S, Q, F = V[1], V[2], V[3], V[4]
     # levels!(v, reverse(levels(v)))
     # @test classes(d) == [s, q, f, a]
     # @test support(d) == [s, q, f]
-
+    @test ismissing(pdf(d, missing))
     @test pdf(d, s) ≈ 0.1
     @test pdf(d, 's') ≈ 0.1
     @test pdf(d, q) ≈ 0.2


### PR DESCRIPTION
By "cousins" I mean the various broadcasted versions we have implemented, and at the `logpdf` variations.

This is needed for #616 