### PR TITLE
Allow finite measures, incl confmat, to handle missing values

### DIFF
--- a/src/MLJBase.jl
+++ b/src/MLJBase.jl
@@ -317,6 +317,13 @@ const INDENT = 4
 const Arr = AbstractArray
 const Vec = AbstractVector
 
+# Note the following are existential (union) types. In particular,
+# ArrMissing{Integer} is not the same as Arr{Union{Missing,Integer}},
+# etc.
+const ArrMissing{T,N} = Arr{<:Union{Missing,T},N}
+const VecMissing{T} = ArrMissing{T,1}
+const CatArrMissing{T,N} = ArrMissing{CategoricalValue{T},N}
+
 const MMI = MLJModelInterface
 const FI  = MLJModelInterface.FullInterface
 # ===================================================================

--- a/src/measures/confusion_matrix.jl
+++ b/src/measures/confusion_matrix.jl
@@ -66,12 +66,14 @@ there no way to specify an ordering different from `levels(y)`, where
 `y` is the target.
 
 """
-function _confmat(ŷ::Vec{<:CategoricalValue}, y::Vec{<:CategoricalValue};
-                          rev::Union{Nothing,Bool}=nothing,
-                          perm::Union{Nothing,Vector{<:Integer}}=nothing,
-                          warn::Bool=true)
+function _confmat(ŷm::CatArrMissing{T,N}, ym::CatArrMissing{T,N};
+                  rev::Union{Nothing,Bool}=nothing,
+                  perm::Union{Nothing,Vector{<:Integer}}=nothing,
+                  warn::Bool=true) where {T,N}
 
-    check_dimensions(ŷ, y)
+    check_dimensions(ŷm, ym)
+    ŷ, y = _skipmissing(ŷm, ym)
+
     levels_ = levels(y)
     nc = length(levels_)
     if rev !== nothing && rev && nc > 2
@@ -204,7 +206,7 @@ is_measure(::ConfusionMatrix) = true
 is_measure_type(::Type{ConfusionMatrix}) = true
 human_name(::Type{<:ConfusionMatrix}) = "confusion matrix"
 target_scitype(::Type{ConfusionMatrix}) =
-    AbstractVector{<:Finite}
+    AbstractVector{<:Union{Missing,Finite}}
 supports_weights(::Type{ConfusionMatrix}) = false
 prediction_type(::Type{ConfusionMatrix}) = :deterministic
 instances(::Type{<:ConfusionMatrix}) = ["confusion_matrix", "confmat"]
@@ -229,7 +231,7 @@ data. For more than two classes, specify an appropriate permutation, as in
 scitype=DOC_ORDERED_FACTOR_BINARY)
 
 # calling behaviour:
-(m::ConfusionMatrix)(ŷ::Vec{<:CategoricalValue}, y::Vec{<:CategoricalValue}) =
+(m::ConfusionMatrix)(ŷ, y) =
     _confmat(ŷ, y, perm=m.perm)
 
 # overloading addition to make aggregation work:

--- a/src/measures/finite.jl
+++ b/src/measures/finite.jl
@@ -39,6 +39,11 @@ A score is reported for every observation.
 """,
 scitype=DOC_FINITE)
 
+# workaround for https://github.com/JuliaLang/julia/issues/41939:
+@static if VERSION < v"1.1"
+    Base.clamp(::Missing, args...) = missing
+end
+
 # for single observation:
 _cross_entropy(d::UnivariateFinite{S,V,R,P}, y, tol) where {S,V,R,P} =
     -log(clamp(pdf(d, y), P(tol), P(1) - P(tol)))

--- a/src/measures/finite.jl
+++ b/src/measures/finite.jl
@@ -41,7 +41,7 @@ scitype=DOC_FINITE)
 
 # workaround for https://github.com/JuliaLang/julia/issues/41939:
 @static if VERSION < v"1.1"
-    Base.clamp(::Missing, args...) = missing
+    Base.clamp(::Missing, lo::Any, hi::Any) = missing
 end
 
 # for single observation:

--- a/src/measures/measures.jl
+++ b/src/measures/measures.jl
@@ -60,13 +60,13 @@ ScientificTypes.info(m, ::Val{:measure}) = info(typeof(m))
 
 ## AGGREGATION
 
-(::Sum)(v) = sum(v)
+(::Sum)(v) = sum(skipmissing(v))
 (::Sum)(v::LittleDict) = sum(values(v))
 
-(::Mean)(v) = mean(v)
+(::Mean)(v) = mean(skipmissing(v))
 (::Mean)(v::LittleDict) = mean(values(v))
 
-(::RootMeanSquare)(v) = sqrt(mean(v.^2))
+(::RootMeanSquare)(v) = sqrt(mean(skipmissing(v).^2))
 
 aggregate(v, measure) = aggregation(measure)(v)
 
@@ -106,7 +106,7 @@ value(m, yhat, X, y, ::Nothing, ::Val{false}, ::Val{true}) = m(yhat, y)
 value(m, yhat, X, y, w,         ::Val{true}, ::Val{true}) = m(yhat, X, y, w)
 value(m, yhat, X, y, ::Nothing, ::Val{true}, ::Val{true}) = m(yhat, X, y)
 
-## helper
+## helpers
 
 function check_pools(ŷ, y)
     levels(y) == levels(ŷ[1]) ||
@@ -115,6 +115,15 @@ function check_pools(ŷ, y)
     return nothing
 end
 
+function _skipmissing(yhat, y)
+    mask = .!(ismissing.(yhat) .| ismissing.(y))
+    return yhat[mask], y[mask]
+end
+
+function _skipmissing(yhat, y, w)
+    mask = .!(ismissing.(yhat) .| ismissing.(y))
+    return yhat[mask], y[mask], w[mask]
+end
 
 ## INCLUDE SPECIFIC MEASURES AND TOOLS
 

--- a/test/measures/measures.jl
+++ b/test/measures/measures.jl
@@ -81,5 +81,19 @@ include("confusion_matrix.jl")
     end
 end
 
+@testset "missing values in aggregation" begin
+    v =[1, 2, missing, 5]
+    @test MLJBase.Sum()(v) == 8
+    @test MLJBase.RootMeanSquare()(v) ≈ sqrt((1 + 4 + 25)/3)
+end
+
+@testset "_skipmissing" begin
+    w = rand(4)
+    @test MLJBase._skipmissing([1, 2, missing, 3], [missing, 5, 6, 7]) ==
+        ([2, 3], [5, 7])
+    @test MLJBase._skipmissing([1, 2, missing, 3], [missing, 5, 6, 7], w) ==
+        ([2, 3], [5, 7], w[[2,4]])
+end
+
 end
 true


### PR DESCRIPTION
This PR addresses part of #616.

It includes adapting the general aggregation methods, such as  `(::Sum)()`, to handle to skip missing values. 