### PR TITLE
Add `Infinite` versions of the proper scoring rules spherical, log

### DIFF
--- a/src/MLJBase.jl
+++ b/src/MLJBase.jl
@@ -183,8 +183,9 @@ export mav, mae, mape, rms, rmsl, rmslp1, rmsp, l1, l2, log_cosh,
     RootMeanSquaredLogError, RMSL, root_mean_squared_log_error, rmsl, rmsle,
     RootMeanSquaredLogProportionalError, rmsl1, RMSLP,
     MAPE, MeanAbsoluteProportionalError, log_cosh_loss, LogCosh, LogCoshLoss,
-    ContinuousBrierScore, CountBrierScore,
-    continuous_brier_score, count_brier_score
+    InfiniteBrierScore, infinite_brier_score,
+    InfiniteSphericalScore, infinite_spherical_score,
+    InfiniteLogScore, infinite_log_score
 
 # measures/confusion_matrix.jl:
 export confusion_matrix, confmat, ConfusionMatrix

--- a/src/measures/continuous.jl
+++ b/src/measures/continuous.jl
@@ -1,28 +1,6 @@
 # ===========================================================
 ## DETERMINISTIC PREDICTIONS
 
-const UD = Distributions.UnivariateDistribution
-const WITH_L2NORM_CONTINUOUS =
-    [@eval(Distributions.$d) for d in [
-        :Chisq,
-        :Gamma,
-        :Beta,
-        :Chi,
-        :Cauchy,
-        :Normal,
-        :Uniform,
-        :Logistic,
-        :Exponential]]
-
-const WITH_L2NORM_COUNT =
-    [@eval(Distributions.$d) for d in [
-        :Poisson,
-        :DiscreteUniform,
-        :DiscreteNonParametric]]
-
-const WITH_L2NORM_INFINITE = vcat(WITH_L2NORM_CONTINUOUS,
-                                  WITH_L2NORM_COUNT)
-
 # -----------------------------------------------------------
 # MeanAbsoluteError
 
@@ -369,8 +347,29 @@ function (log_cosh::LogCoshLoss)(ŷ::Arr{<:T}, y::Arr{<:T}) where T <:Real
 end
 
 # ===========================================================
-## DETERMINISTIC PREDICTIONS
+## PROBABLISTIC PREDICTIONS
 
+const UD = Distributions.UnivariateDistribution
+const WITH_L2NORM_CONTINUOUS =
+    [@eval(Distributions.$d) for d in [
+        :Chisq,
+        :Gamma,
+        :Beta,
+        :Chi,
+        :Cauchy,
+        :Normal,
+        :Uniform,
+        :Logistic,
+        :Exponential]]
+
+const WITH_L2NORM_COUNT =
+    [@eval(Distributions.$d) for d in [
+        :Poisson,
+        :DiscreteUniform,
+        :DiscreteNonParametric]]
+
+const WITH_L2NORM_INFINITE = vcat(WITH_L2NORM_CONTINUOUS,
+                                  WITH_L2NORM_COUNT)
 const FORMULA_INFINITE_BRIER = "``2d(η) - ∫ d(t)^2 dt``"
 _infinite_brier(d, y) = 2*pdf(d, y) - Distributions.pdfsquaredL2norm(d)
 

--- a/src/measures/continuous.jl
+++ b/src/measures/continuous.jl
@@ -31,7 +31,7 @@ struct MeanAbsoluteError <: Measure end
 metadata_measure(MeanAbsoluteError;
                  instances = ["mae", "mav", "mean_absolute_error",
                               "mean_absolute_value"],
-                 target_scitype           = Union{Vec{Continuous},Vec{Count}},
+                 target_scitype           = Union{Arr{Continuous},Arr{Count}},
                  prediction_type          = :deterministic,
                  orientation              = :loss,
                  reports_each_observation = false,
@@ -49,7 +49,7 @@ body=
 ``\\text{mean absolute error} = n^{-1}∑ᵢwᵢ|yᵢ-ŷᵢ|``
 """)
 
-function (::MeanAbsoluteError)(ŷ::Vec{<:Real}, y::Vec{<:Real})
+function (::MeanAbsoluteError)(ŷ::Arr{<:Real}, y::Arr{<:Real})
     check_dimensions(ŷ, y)
     ret = zero(eltype(y))
     for i in eachindex(y)
@@ -59,8 +59,8 @@ function (::MeanAbsoluteError)(ŷ::Vec{<:Real}, y::Vec{<:Real})
     return ret / length(y)
 end
 
-function (::MeanAbsoluteError)(ŷ::Vec{<:Real}, y::Vec{<:Real},
-                 w::Vec{<:Real})
+function (::MeanAbsoluteError)(ŷ::Arr{<:Real}, y::Arr{<:Real},
+                 w::Arr{<:Real})
     check_dimensions(ŷ, y)
     check_dimensions(y, w)
     ret = zero(eltype(y))
@@ -79,7 +79,7 @@ struct RootMeanSquaredError <: Measure end
 metadata_measure(RootMeanSquaredError;
                  instances                = ["rms", "rmse",
                                              "root_mean_squared_error"],
-                 target_scitype           = Union{Vec{Continuous},Vec{Count}},
+                 target_scitype           = Union{Arr{Continuous},Arr{Count}},
                  prediction_type          = :deterministic,
                  orientation              = :loss,
                  reports_each_observation = false,
@@ -97,7 +97,7 @@ body=
 ``\\text{root mean squared error} = \\sqrt{\\frac{∑ᵢwᵢ|yᵢ-ŷᵢ|^2}{∑ᵢwᵢ}}``
 """)
 
-function (::RootMeanSquaredError)(ŷ::Vec{<:Real}, y::Vec{<:Real})
+function (::RootMeanSquaredError)(ŷ::Arr{<:Real}, y::Arr{<:Real})
     check_dimensions(ŷ, y)
     ret = zero(eltype(y))
     for i in eachindex(y)
@@ -107,8 +107,8 @@ function (::RootMeanSquaredError)(ŷ::Vec{<:Real}, y::Vec{<:Real})
     return sqrt(ret / length(y))
 end
 
-function (::RootMeanSquaredError)(ŷ::Vec{<:Real}, y::Vec{<:Real},
-                 w::Vec{<:Real})
+function (::RootMeanSquaredError)(ŷ::Arr{<:Real}, y::Arr{<:Real},
+                 w::Arr{<:Real})
     check_dimensions(ŷ, y)
     ret = zero(eltype(y))
     for i in eachindex(y)
@@ -129,7 +129,7 @@ LPLoss(; p=2.0) = LPLoss(p)
 
 metadata_measure(LPLoss;
                  instances = ["l1", "l2"],
-                 target_scitype           = Union{Vec{Continuous},Vec{Count}},
+                 target_scitype           = Union{Arr{Continuous},Arr{Count}},
                  prediction_type          = :deterministic,
                  orientation              = :loss,
                  reports_each_observation = true,
@@ -146,13 +146,13 @@ Constructor signature: `LPLoss(p=2)`. Reports
 `|ŷ[i] - y[i]|^p` for every index `i`.
 """)
 
-function (m::LPLoss)(ŷ::Vec{<:Real}, y::Vec{<:Real})
+function (m::LPLoss)(ŷ::Arr{<:Real}, y::Arr{<:Real})
     check_dimensions(ŷ, y)
     return abs.((y - ŷ)).^(m.p)
 end
 
-function (m::LPLoss)(ŷ::Vec{<:Real}, y::Vec{<:Real},
-                w::Vec{<:Real})
+function (m::LPLoss)(ŷ::Arr{<:Real}, y::Arr{<:Real},
+                w::Arr{<:Real})
     check_dimensions(ŷ, y)
     check_dimensions(w, y)
     return w .* abs.((y - ŷ)).^(m.p)
@@ -165,7 +165,7 @@ struct RootMeanSquaredLogError <: Measure end
 
 metadata_measure(RootMeanSquaredLogError;
                  instances = ["rmsl", "rmsle", "root_mean_squared_log_error"],
-                 target_scitype           = Union{Vec{Continuous},Vec{Count}},
+                 target_scitype           = Union{Arr{Continuous},Arr{Count}},
                  prediction_type          = :deterministic,
                  orientation              = :loss,
                  reports_each_observation = false,
@@ -184,7 +184,7 @@ n^{-1}∑ᵢ\\log\\left({yᵢ \\over ŷᵢ}\\right)``
 """,
 footer="See also [`rmslp1`](@ref).")
 
-function (::RootMeanSquaredLogError)(ŷ::Vec{<:Real}, y::Vec{<:Real})
+function (::RootMeanSquaredLogError)(ŷ::Arr{<:Real}, y::Arr{<:Real})
     check_dimensions(ŷ, y)
     ret = zero(eltype(y))
     for i in eachindex(y)
@@ -206,7 +206,7 @@ RootMeanSquaredLogProportionalError(; offset=1.0) =
 
 metadata_measure(RootMeanSquaredLogProportionalError;
                  instances                = ["rmslp1", ],
-                 target_scitype           = Union{Vec{Continuous},Vec{Count}},
+                 target_scitype           = Union{Arr{Continuous},Arr{Count}},
                  prediction_type          = :deterministic,
                  orientation              = :loss,
                  reports_each_observation = false,
@@ -227,7 +227,7 @@ n^{-1}∑ᵢ\\log\\left({yᵢ + \\text{offset} \\over ŷᵢ + \\text{offset}}\\
 """,
 footer="See also [`rmsl`](@ref). ")
 
-function (m::RMSLP)(ŷ::Vec{<:Real}, y::Vec{<:Real})
+function (m::RMSLP)(ŷ::Arr{<:Real}, y::Arr{<:Real})
     check_dimensions(ŷ, y)
     ret = zero(eltype(y))
     for i in eachindex(y)
@@ -249,7 +249,7 @@ RootMeanSquaredProportionalError(; tol=eps()) =
 
 metadata_measure(RootMeanSquaredProportionalError;
     instances                = ["rmsp", ],
-    target_scitype           = Union{Vec{Continuous},Vec{Count}},
+    target_scitype           = Union{Arr{Continuous},Arr{Count}},
     prediction_type          = :deterministic,
     orientation              = :loss,
     reports_each_observation = false,
@@ -273,7 +273,7 @@ of such indices.
 
 """)
 
-function (m::RootMeanSquaredProportionalError)(ŷ::Vec{<:Real}, y::Vec{<:Real})
+function (m::RootMeanSquaredProportionalError)(ŷ::Arr{<:Real}, y::Arr{<:Real})
     check_dimensions(ŷ, y)
     ret = zero(eltype(y))
     count = 0
@@ -299,7 +299,7 @@ MeanAbsoluteProportionalError(; tol=eps()) = MeanAbsoluteProportionalError(tol)
 
 metadata_measure(MeanAbsoluteProportionalError;
     instances                = ["mape", ],
-    target_scitype           = Union{Vec{Continuous},Vec{Count}},
+    target_scitype           = Union{Arr{Continuous},Arr{Count}},
     prediction_type          = :deterministic,
     orientation              = :loss,
     reports_each_observation = false,
@@ -322,7 +322,7 @@ where the sum is over indices such that `abs(yᵢ) > tol` and `m` is the number
 of such indices.
 """)
 
-function (m::MeanAbsoluteProportionalError)(ŷ::Vec{<:Real}, y::Vec{<:Real})
+function (m::MeanAbsoluteProportionalError)(ŷ::Arr{<:Real}, y::Arr{<:Real})
     check_dimensions(ŷ, y)
     ret = zero(eltype(y))
     count = 0
@@ -346,7 +346,7 @@ struct LogCoshLoss <: Measure end
 
 metadata_measure(LogCoshLoss;
     instances                = ["log_cosh", "log_cosh_loss"],
-    target_scitype           = Union{Vec{Continuous},Vec{Count}},
+    target_scitype           = Union{Arr{Continuous},Arr{Count}},
     prediction_type          = :deterministic,
     orientation              = :loss,
     reports_each_observation = true,
@@ -363,7 +363,7 @@ body="Reports ``\\log(\\cosh(ŷᵢ-yᵢ))`` for each index `i`. ")
 _softplus(x::T) where T<:Real = x > zero(T) ? x + log1p(exp(-x)) : log1p(exp(x))
 _log_cosh(x::T) where T<:Real = x + _softplus(-2x) - log(convert(T, 2))
 
-function (log_cosh::LogCoshLoss)(ŷ::Vec{<:T}, y::Vec{<:T}) where T <:Real
+function (log_cosh::LogCoshLoss)(ŷ::Arr{<:T}, y::Arr{<:T}) where T <:Real
     check_dimensions(ŷ, y)
     return _log_cosh.(ŷ - y)
 end

--- a/src/measures/finite.jl
+++ b/src/measures/finite.jl
@@ -84,9 +84,10 @@ metadata_measure(BrierScore;
 @create_docs(BrierScore,
 body=
 """
-If `p(y)` is the predicted probability for a *single*
-observation `y`, and `C` all possible classes, then the corresponding
-Brier score for that observation is given by
+Convention as in $PROPER_SCORING_RULES: If `p(y)` is the predicted
+probability for a *single* observation `y`, and `C` all possible
+classes, then the corresponding Brier score for that observation is
+given by
 
 ``2p(y) - \\left(\\sum_{η ∈ C} p(η)^2\\right) - 1``
 

--- a/src/measures/measures.jl
+++ b/src/measures/measures.jl
@@ -1,3 +1,6 @@
+const PROPER_SCORING_RULES = "[Gneiting and Raftery (2007), \"Strictly"*
+    "Proper Scoring Rules, Prediction, and Estimation\""*
+    "](https://doi.org/10.1198/016214506000001437)"
 const DOC_FINITE =
     "`AbstractArray{<:Finite}` (multiclass classification)"
 const DOC_FINITE_BINARY =
@@ -9,6 +12,7 @@ const DOC_ORDERED_FACTOR_BINARY =
     "(binary classification where choice of \"true\" effects the measure)"
 const DOC_CONTINUOUS = "`AbstractArray{Continuous}` (regression)"
 const DOC_COUNT = "`AbstractArray{Count}`"
+const DOC_INFINITE = "AbstractArray{<:Infinite}"
 
 ## TRAITS
 

--- a/test/measures/continuous.jl
+++ b/test/measures/continuous.jl
@@ -23,25 +23,41 @@ rng = StableRNG(666899)
     @test isapprox(mape(yhat, y), (1/1 + 1/2 + 1/3 + 1/4)/4)
 
     uniform = Distributions.Uniform(2, 5)
-    poisson = Distributions.Poisson()
+    betaprime = Distributions.BetaPrime()
     discrete_uniform = Distributions.DiscreteUniform(2, 5)
     w = [2, 3]
 
+    # brier
     yhat = [missing, uniform]
-    @test isapprox(continuous_brier_score(yhat, [42.0, 1.0]), [-1/3,])
-    @test isapprox(continuous_brier_score(yhat, [42.0, 4.0]), [1/3,])
-    @test isapprox(continuous_brier_score(yhat, [42.0, 1.0], w), [-1,])
-    @test isapprox(continuous_brier_score(yhat, [42.0, 4.0], w), [1,])
-    @test_throws(MLJBase.err_brier_distribution(continuous_brier_score,
-                                                poisson),
-                 continuous_brier_score([missing, poisson], [1.0, 1.0]))
-
+    @test isapprox(infinite_brier_score(yhat, [42.0, 1.0]), [-1/3,])
+    @test isapprox(infinite_brier_score(yhat, [NaN, 4.0]), [1/3,])
+    @test isapprox(infinite_brier_score(yhat, [42.0, 1.0], w), [-1,])
+    @test isapprox(infinite_brier_score(yhat, [42.0, 4.0], w), [1,])
     yhat = [missing, discrete_uniform]
-    @test isapprox(count_brier_score(yhat, [42.0, 1.0]), [-1/4,])
-    @test isapprox(count_brier_score(yhat, [42.0, 4.0]), [1/4,])
-    @test_throws(MLJBase.err_brier_distribution(count_brier_score,
-                                                uniform),
-                 count_brier_score([missing, uniform], [1.0, 1.0]))
+    @test isapprox(infinite_brier_score(yhat, [NaN, 1.0]), [-1/4,])
+    @test isapprox(infinite_brier_score(yhat, [42.0, 4.0]), [1/4,])
+
+    # spherical
+    yhat = [missing, uniform]
+    @test isapprox(infinite_spherical_score(yhat, [42.0, 1.0]), [0,])
+    @test isapprox(infinite_spherical_score(yhat, [NaN, 4.0]), [1/sqrt(3),])
+    @test isapprox(infinite_spherical_score(yhat, [42.0, 1.0], w), [0,])
+    @test isapprox(infinite_spherical_score(yhat, [42.0, 4.0], w), [sqrt(3),])
+    yhat = [missing, discrete_uniform]
+    @test isapprox(infinite_spherical_score(yhat, [NaN, 1.0]), [0,])
+    @test isapprox(infinite_spherical_score(yhat, [42.0, 4.0]), [1/2,])
+
+    # log
+    yhat = [missing, uniform]
+    @test isapprox(infinite_log_score(yhat, [NaN, 4.0]), [-log(3),])
+    @test isapprox(infinite_log_score(yhat, [42.0, 4.0], w), [-log(27),])
+    yhat = [missing, discrete_uniform]
+    @test isapprox(infinite_log_score(yhat, [42.0, 4.0]), [-log(4),])
+
+    # errors
+    @test_throws(MLJBase.err_distribution(infinite_brier_score,
+                                                betaprime),
+                 infinite_brier_score([missing, betaprime], [1.0, 1.0]))
 end
 
 @testset "MLJBase.value" begin

--- a/test/measures/measure_search.jl
+++ b/test/measures/measure_search.jl
@@ -37,5 +37,5 @@ ms = map(measures("Brier")) do  m
 end
 
 @test Set(ms) == Set(["BrierLoss", "BrierScore",
-                      "ContinuousBrierScore", "CountBrierScore"])
+                      "InfiniteBrierScore"])
 true


### PR DESCRIPTION
Adds `InfiniteSphericalScore` and `InfiniteLogScore`.

This PR also combines the `ContinuousBrierScore` and `CountBrierScore` into a single `InfiniteBrierScore`. These are from the recent PR #395 has been merged to dev but not master.