### PR TITLE
Multiclass true negative of the conf_mat fix :)

### DIFF
--- a/src/measures/finite.jl
+++ b/src/measures/finite.jl
@@ -1185,14 +1185,12 @@ _mfn(m::CM, return_type::Type{LittleDict}) =
      row_sum .-= diag(m.mat); LittleDict(m.labels, row_sum))
 
 function _mtn(m::CM, return_type::Type{Vector})
-    _sum  = sum(m.mat, dims=2)
-    _sum .= sum(m.mat) .- (_sum .+= sum(m.mat, dims=1)'.+ diag(m.mat))
+    _sum  = sum(m.mat) .- (_mtp(m,return_type) + _mfp(m,return_type) + _mfn(m,return_type))
     return vec(_sum)
 end
 
 function _mtn(m::CM, return_type::Type{LittleDict})
-    _sum  = sum(m.mat, dims=2)
-    _sum .= sum(m.mat) .- (_sum .+= sum(m.mat, dims=1)'.+ diag(m.mat))
+    _sum  = sum(m.mat) .- (_mtp(m,Vector) + _mfp(m,Vector) + _mfn(m,Vector))
     return LittleDict(m.labels, vec(_sum))
 end
 

--- a/src/measures/finite.jl
+++ b/src/measures/finite.jl
@@ -1185,12 +1185,14 @@ _mfn(m::CM, return_type::Type{LittleDict}) =
      row_sum .-= diag(m.mat); LittleDict(m.labels, row_sum))
 
 function _mtn(m::CM, return_type::Type{Vector})
-    _sum  = sum(m.mat) .- (_mtp(m,return_type) + _mfp(m,return_type) + _mfn(m,return_type))
+    _sum = sum(m.mat, dims=2)
+    _sum .= sum(m.mat) .- (_sum .+= sum(m.mat, dims=1)'.- diag(m.mat))
     return vec(_sum)
 end
 
 function _mtn(m::CM, return_type::Type{LittleDict})
-    _sum  = sum(m.mat) .- (_mtp(m,Vector) + _mfp(m,Vector) + _mfn(m,Vector))
+    _sum = sum(m.mat, dims=2)
+    _sum .= sum(m.mat) .- (_sum .+= sum(m.mat, dims=1)'.- diag(m.mat))
     return LittleDict(m.labels, vec(_sum))
 end
 

--- a/test/measures/finite.jl
+++ b/test/measures/finite.jl
@@ -213,8 +213,12 @@ end
 end
 
 @testset "confusion matrix {n}" begin
-    y = coerce([0, 1, 2, 0, 1, 2, 0, 1, 2, 0, 1, 2], Multiclass)
-    ŷ = coerce([0, 1, 0, 0, 0, 2, 1, 2, 0, 1, 1, 2], Multiclass)
+    y = coerce([1, 2, 0, 2, 1, 0, 0, 1, 2, 2, 2, 1, 2,
+                            2, 1, 0, 1, 1, 1, 2, 1, 2, 2, 1, 2, 1,
+                            2, 2, 2], Multiclass)
+    ŷ = coerce([2, 0, 2, 2, 2, 0, 1, 2, 1, 2, 0, 1, 2,
+                            1, 1, 1, 2, 0, 1, 2, 1, 2, 2, 2, 1, 2,
+                            1, 2, 2], Multiclass)
     class_w = Dict(0=>0,2=>2,1=>1)
     cm = MLJBase._confmat(ŷ, y, warn=false)
 
@@ -223,55 +227,83 @@ end
     # ┌─────────────┼─────────────┬─────────────┬─────────────┤
     # │  Predicted  │      0      │      1      │      2      │
     # ├─────────────┼─────────────┼─────────────┼─────────────┤
-    # │      0      │      2      │      1      │      2      │
+    # │      0      │      1      │      1      │      2      │
     # ├─────────────┼─────────────┼─────────────┼─────────────┤
-    # │      1      │      2      │      2      │      0      │
+    # │      1      │      2      │      4      │      4      │
     # ├─────────────┼─────────────┼─────────────┼─────────────┤
-    # │      2      │      0      │      1      │      2      │
+    # │      2      │      1      │      6      │      8      │
     # └─────────────┴─────────────┴─────────────┴─────────────┘
+
+    cm_tp   = [1; 4; 8]
+    cm_tn   = [22; 12; 8]
+    cm_fp   = [1+2; 2+4; 1+6]
+    cm_fn   = [2+1; 1+6; 2+4]
+    cm_prec = cm_tp ./ ( cm_tp + cm_fp  )
+    cm_rec  = cm_tp ./ ( cm_tp + cm_fn  )
+
+    # Check if is positive
+    m = MulticlassTruePositive(;return_type=Vector)
+    @test  [0; 0; 0] <= m(ŷ, y) == cm_tp 
+    m = MulticlassTrueNegative(;return_type=Vector)
+    @test  [0; 0; 0] <= m(ŷ, y) == cm_tn 
+    m = MulticlassFalsePositive(;return_type=Vector)
+    @test  [0; 0; 0] <= m(ŷ, y) == cm_fp 
+    m = MulticlassFalseNegative(;return_type=Vector)
+    @test  [0; 0; 0] <= m(ŷ, y) == cm_fn
+
+    # Check if is in [0,1]
+    m = MulticlassTruePositiveRate(average=no_avg;return_type=Vector)
+    @test  [0; 0; 0] <= m(ŷ, y) == cm_tp ./ (cm_fn.+cm_tp) <= [1; 1; 1]
+    m = MulticlassTrueNegativeRate(average=no_avg;return_type=Vector)
+    @test  [0; 0; 0] <= m(ŷ, y) == cm_tn ./ (cm_tn.+cm_fp) <= [1; 1; 1]
+    m = MulticlassFalsePositiveRate(average=no_avg;return_type=Vector)
+    @test  [0; 0; 0] <= m(ŷ, y) == 1 .- cm_tn ./ (cm_tn.+cm_fp) <= [1; 1; 1]
+    m = MulticlassFalseNegativeRate(average=no_avg;return_type=Vector)
+    @test  [0; 0; 0] <= m(ŷ, y) == 1 .- cm_tp ./ (cm_fn.+cm_tp) <= [1; 1; 1]
 
     #`no_avg` and `LittleDict`
     @test collect(values(MulticlassPrecision(average=no_avg)(cm))) ≈
         collect(values(MulticlassPrecision(average=no_avg)(ŷ, y))) ≈
-        [0.4; 0.5; 2/3]
+        cm_prec
     @test MulticlassPrecision(average=macro_avg)(cm) ≈
-        MulticlassPrecision(average=macro_avg)(ŷ, y) ≈ mean([0.4; 0.5; 2/3])
+        MulticlassPrecision(average=macro_avg)(ŷ, y) ≈ mean(cm_prec)
     @test collect(keys(MulticlassPrecision(average=no_avg)(cm)))  ==
         collect(keys(MulticlassPrecision(average=no_avg)(ŷ, y))) ==
         ["0"; "1"; "2"]
     @test collect(values(MulticlassRecall(average=no_avg)(cm))) ≈
         collect(values(MulticlassRecall(average=no_avg)(ŷ, y))) ≈
-        [0.5; 0.5; 0.5]
+        cm_rec
     @test collect(values(MulticlassFScore(average=no_avg)(cm))) ≈
         collect(values(MulticlassFScore(average=no_avg)(ŷ, y))) ≈
-        [4/9; 0.5; 4/7]
+        2 ./ ( 1 ./ cm_prec + 1 ./ cm_rec )
 
     #`no_avg` and `LittleDict` with class weights
     @test collect(values(MulticlassPrecision(average=no_avg)(cm, class_w))) ≈
         collect(values(MulticlassPrecision(average=no_avg)(ŷ, y, class_w))) ≈
-        [0.4; 0.5; 2/3] .* [0; 1; 2]
+        cm_prec .* [0; 1; 2]
     @test collect(values(MulticlassRecall(average=no_avg)(cm, class_w))) ≈
         collect(values(MulticlassRecall(average=no_avg)(ŷ, y, class_w))) ≈
-        [0.5; 0.5; 0.5] .* [0; 1; 2]
+        cm_rec .* [0; 1; 2]
     @test collect(values(MulticlassFScore(average=no_avg)(cm, class_w))) ≈
         collect(values(MulticlassFScore(average=no_avg)(ŷ, y, class_w))) ≈
-        [4/9; 0.5; 4/7] .* [0; 1; 2]
+        2 ./ ( 1 ./ cm_prec + 1 ./ cm_rec ) .* [0; 1; 2]
 
     #`macro_avg` and `LittleDict`
     macro_prec = MulticlassPrecision(average=macro_avg)
     macro_rec  = MulticlassRecall(average=macro_avg)
 
-    @test macro_prec(cm)    ≈ macro_prec(ŷ, y)    ≈ mean([0.4, 0.5, 2/3])
-    @test macro_rec(cm)     ≈ macro_rec(ŷ, y)     ≈ mean([0.5; 0.5; 0.5])
-    @test macro_f1score(cm) ≈ macro_f1score(ŷ, y) ≈ mean([4/9; 0.5; 4/7])
+    @test macro_prec(cm)    ≈ macro_prec(ŷ, y)    ≈ mean(cm_prec)
+    @test macro_rec(cm)     ≈ macro_rec(ŷ, y)     ≈ mean(cm_rec)
+    @test macro_f1score(cm) ≈ macro_f1score(ŷ, y) ≈ mean(2 ./ ( 1 ./ cm_prec + 1 ./ cm_rec ))
 
     #`micro_avg` and `LittleDict`
     micro_prec = MulticlassPrecision(average=micro_avg)
     micro_rec  = MulticlassRecall(average=micro_avg)
 
-    @test micro_prec(cm)    == micro_prec(ŷ, y)    == 0.5
-    @test micro_rec(cm)     == micro_rec(ŷ, y)     == 0.5
-    @test micro_f1score(cm) == micro_f1score(ŷ, y) == 0.5
+    @test micro_prec(cm)    == micro_prec(ŷ, y)    == sum(cm_tp) ./ sum(cm_fp.+cm_tp)
+    @test micro_rec(cm)     == micro_rec(ŷ, y)     == sum(cm_tp) ./ sum(cm_fn.+cm_tp)
+    @test micro_f1score(cm) == micro_f1score(ŷ, y) == 
+    2 ./ ( 1 ./ ( sum(cm_tp) ./ sum(cm_fp.+cm_tp) ) + 1 ./ ( sum(cm_tp) ./ sum(cm_fn.+cm_tp) ) )
 
     #`no_avg` and `Vector` with class weights
     vec_precision = MulticlassPrecision(return_type=Vector)
@@ -279,11 +311,11 @@ end
     vec_f1score   = MulticlassFScore(return_type=Vector)
 
     @test vec_precision(cm, class_w) ≈ vec_precision(ŷ, y, class_w) ≈
-        mean([0.4; 0.5; 2/3] .* [0; 1; 2])
+        mean(cm_prec .* [0; 1; 2])
     @test vec_recall(cm, class_w)    ≈ vec_recall(ŷ, y, class_w)    ≈
-        mean([0.5; 0.5; 0.5] .* [0; 1; 2])
+        mean(cm_rec .* [0; 1; 2])
     @test vec_f1score(cm, class_w)   ≈ vec_f1score(ŷ, y, class_w)   ≈
-        mean([4/9; 0.5; 4/7] .* [0; 1; 2])
+        mean(2 ./ ( 1 ./ cm_prec + 1 ./ cm_rec ) .* [0; 1; 2])
 
     #`macro_avg` and `Vector`
     v_ma_prec = MulticlassPrecision(average=macro_avg,
@@ -291,26 +323,27 @@ end
     v_ma_rec  = MulticlassRecall(average=macro_avg, return_type=Vector)
     v_ma_f1   = MulticlassFScore(average=macro_avg, return_type=Vector)
 
-    @test v_ma_prec(cm) ≈ v_ma_prec(ŷ, y) ≈ mean([0.4, 0.5, 2/3])
-    @test v_ma_rec(cm)  ≈ v_ma_rec(ŷ, y)  ≈ mean([0.5; 0.5; 0.5])
-    @test v_ma_f1(cm)   ≈ v_ma_f1(ŷ, y)   ≈ mean([4/9; 0.5; 4/7])
+    @test v_ma_prec(cm) ≈ v_ma_prec(ŷ, y) ≈ mean(cm_prec)
+    @test v_ma_rec(cm)  ≈ v_ma_rec(ŷ, y)  ≈ mean(cm_rec)
+    @test v_ma_f1(cm)   ≈ v_ma_f1(ŷ, y)   ≈ mean(2 ./ ( 1 ./ cm_prec + 1 ./ cm_rec ))
 
     #`macro_avg` and `Vector` with class weights
     @test v_ma_prec(cm, class_w) ≈ v_ma_prec(ŷ, y, class_w) ≈
-        mean([0.4, 0.5, 2/3] .* [0, 1, 2])
+        mean(cm_prec .* [0, 1, 2])
     @test v_ma_rec(cm, class_w)  ≈ v_ma_rec(ŷ, y, class_w)  ≈
-        mean([0.5; 0.5; 0.5] .* [0, 1, 2])
+        mean(cm_rec .* [0, 1, 2])
     @test v_ma_f1(cm, class_w)   ≈ v_ma_f1(ŷ, y, class_w)   ≈
-        mean([4/9; 0.5; 4/7] .* [0, 1, 2])
+        mean(2 ./ ( 1 ./ cm_prec + 1 ./ cm_rec ) .* [0, 1, 2])
 
     #`micro_avg` and `Vector`
     v_mi_prec = MulticlassPrecision(average=micro_avg, return_type=Vector)
     v_mi_rec  = MulticlassRecall(average=micro_avg, return_type=Vector)
     v_mi_f1   = MulticlassFScore(average=micro_avg, return_type=Vector)
 
-    @test v_mi_prec(cm) == v_mi_prec(ŷ, y) == 0.5
-    @test v_mi_rec(cm)  == v_mi_rec(ŷ, y)  == 0.5
-    @test v_mi_f1(cm)   == v_mi_f1(ŷ, y)   == 0.5
+    @test v_mi_prec(cm) == v_mi_prec(ŷ, y) == sum(cm_tp) ./ sum(cm_fp.+cm_tp)
+    @test v_mi_rec(cm)  == v_mi_rec(ŷ, y)  == sum(cm_tp) ./ sum(cm_fn.+cm_tp)
+    @test v_mi_f1(cm)   == v_mi_f1(ŷ, y)   == 
+    2 ./ ( 1 ./ ( sum(cm_tp) ./ sum(cm_fp.+cm_tp) ) + 1 ./ ( sum(cm_tp) ./ sum(cm_fn.+cm_tp) ) )
 end
 
 @testset "Metadata binary" begin


### PR DESCRIPTION
The previous version was returning negative values for **true negatives**:

- Confusion Matrix
<img width="421" alt="conf_mat" src="https://user-images.githubusercontent.com/39775297/132104830-3a6a89de-b4e3-4f96-ba82-eb94df8dc638.png">

- Old _mtn function:
<img width="538" alt="tn_old" src="https://user-images.githubusercontent.com/39775297/132104829-6f117eef-91d1-426b-a04d-8991595bf46d.png">

- New _mtn function:
<img width="531" alt="tn_new" src="https://user-images.githubusercontent.com/39775297/132104828-3a312128-3a63-4d53-ac62-14cb4c8dd262.png">

Source: https://stats.stackexchange.com/a/338240/306362
