### PR TITLE
Pipelines without macros

### DIFF
--- a/src/MLJBase.jl
+++ b/src/MLJBase.jl
@@ -147,12 +147,15 @@ export machine, Machine, fit!, report, fit_only!
 export make_blobs, make_moons, make_circles, make_regression
 
 # composition:
-export machines, sources, @from_network, @pipeline, Stack,
+export machines, sources, @from_network, @pipeline, Pipeline, Stack,
     glb, @tuple, node, @node, sources, origins, return!,
     nrows_at_source, machine,
     rebind!, nodes, freeze!, thaw!, Node, AbstractNode,
     DeterministicSurrogate, ProbabilisticSurrogate, UnsupervisedSurrogate,
-    DeterministicComposite, ProbabilisticComposite, UnsupervisedComposite
+    DeterministicComposite, ProbabilisticComposite, UnsupervisedComposite,
+    DeterministicPipeline, ProbabilisticPipeline, IntervalPipeline,
+    UnsupervisedPipeline, StaticPipeline
+
 
 # aliases to the above,  kept for backwards compatibility:
 export  DeterministicNetwork, ProbabilisticNetwork, UnsupervisedNetwork
@@ -366,6 +369,7 @@ include("composition/models/methods.jl")
 include("composition/models/from_network.jl")
 include("composition/models/inspection.jl")
 include("composition/models/pipelines.jl")
+include("composition/models/pipelines2.jl")
 include("composition/models/_wrapped_function.jl")
 
 include("operations.jl")

--- a/src/MLJBase.jl
+++ b/src/MLJBase.jl
@@ -361,9 +361,9 @@ include("composition/abstract_types.jl")
 include("composition/learning_networks/nodes.jl")
 include("composition/learning_networks/inspection.jl")
 include("composition/learning_networks/machines.jl")
-@static if VERSION ≥ v"1.3.0-"
-    include("composition/learning_networks/arrows.jl")
-end
+# @static if VERSION ≥ v"1.3.0-"
+#     include("composition/learning_networks/arrows.jl")
+# end
 
 include("composition/models/methods.jl")
 include("composition/models/from_network.jl")

--- a/src/composition/learning_networks/inspection.jl
+++ b/src/composition/learning_networks/inspection.jl
@@ -27,6 +27,7 @@ function tree(W::Node)
     return NamedTuple{keys}(values)
 end
 tree(s::Source) = (source = s,)
+tree(n::ErrorNode) = (node = n,)
 
 # """
 #    args(tree; train=false)

--- a/src/composition/learning_networks/nodes.jl
+++ b/src/composition/learning_networks/nodes.jl
@@ -216,6 +216,7 @@ istoobig(d::Tuple{AbstractNode}) = length(d) > 10
 _formula(stream::IO, X::AbstractNode, indent) =
     (print(stream, repeat(' ', indent));_formula(stream, X, 0, indent))
 _formula(stream::IO, X::Source, depth, indent) = show(stream, X)
+_formula(stream::IO, X::ErrorNode, depth, indent) = show(stream, X)
 function _formula(stream, X::Node, depth, indent)
     operation_name = string(typeof(X.operation).name.mt.name)
     anti = max(length(operation_name) - INDENT)

--- a/src/composition/models/pipelines.jl
+++ b/src/composition/models/pipelines.jl
@@ -130,8 +130,6 @@ end
 
 super_type(model::Model) = super_type(typeof(model))
 
-super_type(f) = Function
-
 # does expression processing, syntax and semantic
 # checks. is_probabilistic is `true`, `false` or `missing`.
 #function pipeline_preprocess(modl, ex, is_probabilistic::Union{Missing,Bool})

--- a/src/composition/models/pipelines.jl
+++ b/src/composition/models/pipelines.jl
@@ -95,27 +95,6 @@ end
 
 ## PREPROCESSING
 
-# `M` is a model type and the return value a `Symbol`. The
-# `existing_names` gets updated.
-function generate_name!(M::DataType, existing_names)
-    str = split(string(M), '{') |> first
-    candidate = split(str, '.') |> last |> snakecase |> Symbol
-    candidate in existing_names ||
-        (push!(existing_names, candidate); return candidate)
-    n = 2
-    new_candidate = candidate
-    while true
-        new_candidate = string(candidate, n) |> Symbol
-        new_candidate in existing_names || break
-        n += 1
-    end
-    push!(existing_names, new_candidate)
-    return new_candidate
-end
-
-generate_name!(model::Model, existing_names) =
-    generate_name!(typeof(model), existing_names)
-
 pipe_alert(message) = throw(ArgumentError("@pipeline error.\n"*
                                      string(message)))
 pipe_alert(k::Int) = throw(ArgumentError("@pipeline error $k. "))
@@ -151,6 +130,8 @@ end
 
 super_type(model::Model) = super_type(typeof(model))
 
+super_type(f) = Function
+
 # does expression processing, syntax and semantic
 # checks. is_probabilistic is `true`, `false` or `missing`.
 #function pipeline_preprocess(modl, ex, is_probabilistic::Union{Missing,Bool})
@@ -181,7 +162,7 @@ function pipeline_preprocess(modl, exs...)
 
     function add_model(ex)
         model_, model = eval_and_reassign(modl, ex)
-        fieldname_ = generate_name!(model, fieldnames_)
+        fieldname_ = generate_name!(model, fieldnames_, only=Model)
         push!(models_and_functions_, model_)
         push!(models_and_functions, model)
         push!(models_, model_)
@@ -355,7 +336,7 @@ function pipeline_preprocess(modl, exs...)
     # check consistency of user-defined prediction_type and infer
     # final super type:
     if is_supervised
-        if pred_type != nothing
+        if pred_type !== nothing
             super = super_type(pred_type)
             supervised_is_last && !(supervised_model isa super) &&
                 pipe_alert("The pipeline's last component model has type "*
@@ -375,7 +356,7 @@ function pipeline_preprocess(modl, exs...)
             super = Deterministic
         end
     else
-        if pred_type != nothing
+        if pred_type !== nothing
             @warn "Pipeline appears to have no supervised "*
             "component models. Ignoring declaration "*
             "`prediction_type=$(pred_type)`. "

--- a/src/composition/models/pipelines2.jl
+++ b/src/composition/models/pipelines2.jl
@@ -191,6 +191,7 @@ PCA = @load PCA pkg=MultivariateStats add=true
 pipe1 = MLJBase.table |> ContinuousEncoder |> Standardizer
 pipe2 = PCA |> LinearRegressor
 pipe1 |> pipe2
+```
 
 ### Special operations
 

--- a/src/composition/models/pipelines2.jl
+++ b/src/composition/models/pipelines2.jl
@@ -1,0 +1,246 @@
+# Code to construct pipelines without macros
+
+# ## Note on mutability.
+
+# The components in a pipeline, as defined here, can be replaced so
+# long as their "abstract supertype" (eg, `Probabilistic`) remains the
+# same. This is the type returned by `abstract_type()`; in the present
+# code it will always be one of the types listed in
+# `SUPPORTED_TYPES_FOR_PIPELINES` below, or `Any`, if `component` is
+# not a model (which, by assumption, means it is callable).
+
+
+# # HELPERS
+
+# modify collection of symbols to guarantee uniqueness. For example,
+# individuate([:x, :y, :x, :x]) = [:x, :y, :x2, :x3])
+function individuate(v)
+    isempty(v) && return v
+    ret = [first(v),]
+    for s in v[2:end]
+        s in ret || (push!(ret, s); continue)
+        n = 2
+        candidate = s
+        while true
+            candidate = string(s, n) |> Symbol
+            candidate in ret || break
+            n += 1
+        end
+        push!(ret, candidate)
+    end
+    return ret
+end
+
+
+# # TYPES
+
+const SUPPORTED_TYPES_FOR_PIPELINES = [
+    :Deterministic,
+    :Probabilistic,
+    :Interval,
+    :Unsupervised,
+    :Static]
+
+const PIPELINE_TYPE_GIVEN_TYPE = Dict(
+    :Deterministic => :DeterministicPipeline,
+    :Probabilistic => :ProbabilisticPipeline,
+    :Interval      => :IntervalPipeline,
+    :Unsupervised  => :UnsupervisedPipeline,
+    :Static        => :StaticPipeline)
+
+const COMPOSITE_TYPE_GIVEN_TYPE = Dict(
+    :Deterministic => :DeterministicComposite,
+    :Probabilistic => :ProbabilisticComposite,
+    :Interval      => :IntervalComposite,
+    :Unsupervised  => :UnsupervisedComposite,
+    :Static        => :StaticComposite)
+
+const PREDICTION_TYPE_OPTIONS = [:deterministic,
+                                 :probabilistic,
+                                 :interval]
+
+for T_ex in SUPPORTED_TYPES_FOR_PIPELINES
+    P_ex = PIPELINE_TYPE_GIVEN_TYPE[T_ex]
+    C_ex = COMPOSITE_TYPE_GIVEN_TYPE[T_ex]
+    quote
+        mutable struct $P_ex{N<:NamedTuple} <: $C_ex
+            named_components::N
+            cache::Bool
+        end
+    end |> eval
+end
+
+# hack an alias for the union type, `SomePipeline{N}`:
+const _TYPE_EXS = map(values(PIPELINE_TYPE_GIVEN_TYPE)) do P_ex
+    Meta.parse("$(P_ex){N}")
+end
+quote
+    const SomePipeline{N,O} =
+        Union{$(_TYPE_EXS...)}
+end |> eval
+
+
+# # GENERIC CONSTRUCTOR
+
+const PRETTY_PREDICTION_OPTIONS =
+    join([string("`:", opt, "`") for opt in PREDICTION_TYPE_OPTIONS],
+         ", ",
+         " and ")
+const ERR_TOO_MANY_SUPERVISED = ArgumentError(
+    "More than one supervised model in a pipeline is not permitted")
+const ERR_EMPTY_PIPELINE = ArgumentError(
+    "Cannot create an empty pipeline. ")
+err_prediction_type_conflict(supervised_model, prediction_type) =
+    ArgumentError("The pipeline's last component model has type "*
+                  "`$(typeof(supervised_model))`, which conflicts "*
+                  "the declaration "*
+                  "`prediction_type=$prediction_type`. ")
+const INFO_TREATING_AS_DETERMINISTIC =
+    "Treating pipeline as a `Deterministic` predictor.\n"*
+    "To override, use `Pipeline` constructor with `prediction_type=...`. "*
+    "Options are $PRETTY_PREDICTION_OPTIONS. "
+const ERR_INVALID_PREDICTION_TYPE = ArgumentError(
+    "Invalid `prediction_type`. Options are $PRETTY_PREDICTION_OPTIONS. ")
+const WARN_IGNORING_PREDICTION_TYPE =
+    "Pipeline appears to have no supervised "*
+    "component models. Ignoring declaration "*
+    "`prediction_type=$(prediction_type)`. "
+const ERR_MIXED_PIPELINE_SPEC = ArgumentError(
+    "Either specify all pipeline components without names, as in "*
+    "`Pipeline(model1, model2)` or all specify names for all "*
+    "components, as in `Pipeline(myfirstmodel=model1, mysecondmodel=model2)`. ")
+
+
+# Following checks `components` is a valid sequence, modifies `names`
+# to make them unique, and returns a named tuple using the abstract
+# component types. See the "Note on mutability" above.
+function pipe_named_tuple(names, components)
+    isempty(names) && throw(ERR_EMPTY_PIPELINE)
+
+    # make keys unique:
+    names = names |> individuate |> Tuple
+
+    # check sequence:
+    supervised_components = filter(components) do c
+        c isa Supervised
+    end
+    length(supervised_components) < 2 ||
+        throw(ERR_TOO_MANY_SUPERVISED)
+
+    # return the named tuple:
+    types = abstract_type.(components)
+    NamedTuple{names,Tuple{types...}}(components)
+end
+
+# in the public constructor components appear either in `args` (names
+# automatically generated) or in `kwargs` (but not both):
+function Pipeline(args...; prediction_type=nothing,
+                  operation=predict,
+                  cache=true,
+                  kwargs...)
+
+    isempty(args) || isempty(kwargs) ||
+        throw(ERR_MIXED_PIPELINE_SPEC)
+
+    operation in eval.(PREDICT_OPERATIONS) ||
+        throw(ERR_INVALID_OPERATION)
+
+    prediction_type in PREDICTION_TYPE_OPTIONS || prediction_type === nothing ||
+        throw(ERR_INVALID_PREDICTION_TYPE)
+
+    # construct the named tuple of components:
+    if isempty(args)
+        _names = keys(kwargs)
+        components = values(values(kwargs))
+    else
+        _names = Symbol[]
+        for c in args
+            generate_name!(c, _names, only=Model)
+        end
+        components = args
+    end
+    named_components = pipe_named_tuple(_names, components)
+
+    # Is this a supervised pipeline?
+    idx = findfirst(components) do c
+        c isa Supervised
+    end
+    is_supervised = idx !== nothing
+    is_supervised && @inbounds supervised_model = components[idx]
+
+    # Is this a static pipeline? A component is *static* if it is an
+    # instance of `Static <: Unsupervised` *or* a callable (anything
+    # that is not a model, by assumption). When all the components are
+    # static, the pipeline will be a `StaticPipeline`.
+    static_components = filter(components) do m
+        !(m isa Model) || m isa Static
+    end
+
+    is_static = length(static_components) == length(components)
+
+    # To make final pipeline type determination, we need to determine
+    # the corresonding abstract type (eg, `Probablistic`) here called
+    # `super`:
+    if is_supervised
+        supervised_is_last = last(components) === supervised_model
+        if prediction_type !== nothing
+            super = super_type(prediction_type)
+            supervised_is_last && !(supervised_model isa super) &&
+                throw(err_prediction_type_conflict(e, prediction_type))
+        elseif supervised_is_last
+            if operation != predict
+                super = Deterministic
+            else
+                super = abstract_type(supervised_model)
+            end
+        else
+            A = abstract_type(supervised_model)
+            A == Deterministic || operation !== predict ||
+                @info INFO_TREATING_AS_DETERMINISTIC
+            super = Deterministic
+        end
+    else
+        prediction_type === nothing ||
+            @warn WARN_IGNORING_PREDICTION_TYPE
+        super = is_static ? Static : Unsupervised
+    end
+
+    # dispatch on `super` to construct the appropriate type:
+    _pipeline(super, named_components, cache)
+end
+
+# where the method called in the last line will be one of these:
+for T_ex in SUPPORTED_TYPES_FOR_PIPELINES
+    P_ex = PIPELINE_TYPE_GIVEN_TYPE[T_ex]
+    quote
+        _pipeline(::Type{<:$T_ex}, args...) =
+            $P_ex(args...)
+    end |> eval
+end
+
+
+# # PROPERTY ACCESS
+
+err_pipeline_bad_property(p, name) = ErrorException(
+    "type $(typeof(p)) has no property $name")
+
+Base.propertynames(p::SomePipeline{<:NamedTuple{names}}) where names =
+    (names..., :cache)
+
+function Base.getproperty(p::SomePipeline{<:NamedTuple{names}},
+                          name::Symbol) where names
+    name === :cache && return getfield(p, :cache)
+    name in names && return getproperty(getfield(p, :named_components), name)
+    throw(err_pipeline_bad_property(p, name))
+end
+
+function Base.setproperty!(p::SomePipeline{<:NamedTuple{names,types}},
+                           name::Symbol, value) where {names,types}
+    name === :cache && return setfield!(p, :cache, value)
+    idx = findfirst(==(name), names)
+    idx === nothing && throw(err_pipeline_bad_property(p, name))
+    components = getfield(p, :named_components) |> values |> collect
+    @inbounds components[idx] = value
+    named_components = NamedTuple{names,types}(Tuple(components))
+    setfield!(p, :named_components, named_components)
+end

--- a/src/composition/models/pipelines2.jl
+++ b/src/composition/models/pipelines2.jl
@@ -156,6 +156,49 @@ function pipe_named_tuple(names, components)
 
 end
 
+"""
+    Pipeline(component1, component2, ... , componentk; options...)
+    Pipeline(name1=component1, name2=component2, ..., componentk; options...)
+
+Create an instance of composite model type which sequentially composes
+the specified components in order. This means `component1` receives
+inputs, whose output is passed to `component2`, and so forth. A
+"component" is either a `Model` instance, a model type (converted
+immediately to its default instance) or any callable object.
+
+At most one of the components may be a supervised model, but this
+model can appear in any position.
+
+The `@pipeline` macro accepts key-word `options` discussed further
+below.
+
+Ordinary functions (and other callables) may be inserted in the
+pipeline as shown in the following example:
+
+    Pipeline(X->coerce(X, :age=>Continuous), OneHotEncoder, ConstantClassifier)
+
+### Optional key-word arguments
+
+- `prediction_type`  -
+  prediction type of the pipeline; possible values: `:deterministic`,
+  `:probabilistic`, `:interval` (default=`:deterministic` if not inferable)
+
+- `operation` - operation applied to the supervised component model,
+  when present; possible values: `predict`, `predict_mean`,
+  `predict_median`, `predict_mode` (default=`predict`)
+
+- `cache` - whether the internal machines created for component models
+  should cache model-specific representations of data. See [`machine`](@ref).
+
+!!! warning "Set `cache=false` to guarantee data anonymization"
+
+    This precaution applies to composite models, and only to those
+    implemented using learning networks.
+
+To build more complicated non-branching pipelines, refer to the MLJ
+manual sections on composing models.
+
+"""
 function Pipeline(args...; prediction_type=nothing,
                   operation=predict,
                   cache=true,

--- a/src/sources.jl
+++ b/src/sources.jl
@@ -129,3 +129,14 @@ function Base.show(stream::IO, ::MIME"text/plain", source::Source)
     return nothing
 end
 
+
+## SPECIAL NODE TO THROW EXCEPTION WHEN CALLED
+
+struct ErrorNode{E} <: AbstractNode
+    exception::E
+end
+(n::ErrorNode)(; kwargs...) = throw(n.exception)
+
+origins(::ErrorNode) = AbstractNode[]
+nodes(::ErrorNode) = AbstractNode[]
+machines(::ErrorNode) = Machine[]

--- a/src/sources.jl
+++ b/src/sources.jl
@@ -135,7 +135,7 @@ end
 struct ErrorNode{E} <: AbstractNode
     exception::E
 end
-(n::ErrorNode)(; kwargs...) = throw(n.exception)
+(n::ErrorNode)(args...; kwargs...) = throw(n.exception)
 
 origins(::ErrorNode) = AbstractNode[]
 nodes(::ErrorNode) = AbstractNode[]

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -330,3 +330,65 @@ function available_name(modl, name)
     end
     return new_name
 end
+
+"""
+    generate_name!(M, existing_names; only=Union{Function,Type}, substitute=:f)
+
+Given a type `M` (e.g., `MyHugeInteger{N}`) return a symbolic,
+snake-case, representation of the type name (such as
+`my_huge_integer`). The symbol is pushed to `existing_names`, which must be
+an `AbstractVector` to which a `Symbol` can be pushed.
+
+If the snake-case representation already exists in `existing_names` a
+suitable integer is appended to the name.
+
+If `only` is specified, then the operation is restricted to those `M`
+for which `M isa only`. In all other cases the symbolic name is
+generated using `substitute` as the base symbol.
+
+If `M <: Union{Type,Function}` is false, it is replaced with `typeof(M)`.
+
+```
+existing_names = []
+julia> generate_name!(Vector{Int}, existing_names)
+:vector
+
+julia> generate_name!(Vector{Int}, existing_names)
+:vector2
+
+julia> generate_name!(AbstractFloat, existing_names)
+:abstract_float
+
+julia> generate_name!(Int, existing_names, only=Array, substitute=:not_array)
+:not_array
+
+julia> generate_name!(Int, existing_names, only=Array, substitute=:not_array)
+:not_array2
+
+"""
+function generate_name!(M::DataType,
+                        existing_names;
+                        only=Any,
+                        substitute=:f)
+    if M <: only
+        str = split(string(M), '{') |> first
+        candidate = split(str, '.') |> last |> snakecase |> Symbol
+    else
+        candidate = substitute
+    end
+
+    candidate in existing_names ||
+        (push!(existing_names, candidate); return candidate)
+    n = 2
+    new_candidate = candidate
+    while true
+        new_candidate = string(candidate, n) |> Symbol
+        new_candidate in existing_names || break
+        n += 1
+    end
+    push!(existing_names, new_candidate)
+    return new_candidate
+end
+
+generate_name!(model, existing_names; kwargs...) =
+    generate_name!(typeof(model), existing_names; kwargs...)

--- a/test/composition/models/pipelines.jl
+++ b/test/composition/models/pipelines.jl
@@ -593,8 +593,4 @@ mach = fit!(machine(p, X, y), verbosity=0)
 
 end
 
-
-## OPERATION KEYWORD
-
-
 true

--- a/test/composition/models/pipelines2.jl
+++ b/test/composition/models/pipelines2.jl
@@ -1,0 +1,151 @@
+module TestPipelines2
+
+using MLJBase
+using Test
+
+@testset "helpers" begin
+    @test MLJBase.individuate([:x, :y, :x, :z, :y, :x]) ==
+        [:x, :y, :x2, :z, :y2, :x3]
+end
+
+
+# # DUMMY MODELS
+
+mutable struct MyTransformer2 <: Static
+    ftr::Symbol
+end
+
+MLJBase.transform(transf::MyTransformer2, verbosity, X) =
+    selectcols(X, transf.ftr)
+
+mutable struct MyDeterministic <: Deterministic
+    x::Symbol
+end
+
+mutable struct MyProbabilistic <: Probabilistic
+    x::Symbol
+end
+
+mutable struct MyUnsupervised <: Unsupervised
+    x::Symbol
+end
+
+mutable struct MyInterval <: Interval
+    x::Symbol
+end
+
+d = MyDeterministic(:d)
+p = MyProbabilistic(:p)
+u = MyUnsupervised(:u)
+s = MyTransformer2(:s)
+i = MyInterval(:i)
+m = MLJBase.matrix
+t = MLJBase.table
+
+@testset "pipe_named_tuple" begin
+    @test_throws MLJBase.ERR_EMPTY_PIPELINE MLJBase.pipe_named_tuple((),())
+    @test_throws(MLJBase.ERR_TOO_MANY_SUPERVISED,
+                 MLJBase.pipe_named_tuple((:foo, :foo, :foo), (d, u, p)))
+    _names      = (:trf, :fun, :fun, :trf, :clf)
+    components = (u,    m,    t,    u,    d)
+    @test MLJBase.pipe_named_tuple(_names, components) ==
+        NamedTuple{(:trf, :fun, :fun2, :trf2, :clf),
+                   Tuple{Unsupervised,
+                         Any,
+                         Any,
+                         Unsupervised,
+                         Deterministic}}(components)
+end
+
+@testset "public constructor" begin
+    # un-named components:
+    @test Pipeline(m, t, u) isa UnsupervisedPipeline
+    @test Pipeline(m, t, u, p) isa ProbabilisticPipeline
+    @test Pipeline(m, t, u, p, operation=predict_mean) isa DeterministicPipeline
+    @test Pipeline(u, p, u, operation=predict_mean) isa DeterministicPipeline
+    @test Pipeline(m, t) isa StaticPipeline
+    @test Pipeline(m, t, s) isa StaticPipeline
+    @test Pipeline(m, t, s, d) isa DeterministicPipeline
+    @test Pipeline(m, t, i) isa IntervalPipeline
+    @test_logs((:info, MLJBase.INFO_TREATING_AS_DETERMINISTIC),
+               @test Pipeline(m, t, u, p, u) isa DeterministicPipeline)
+    @test_logs((:info, MLJBase.INFO_TREATING_AS_DETERMINISTIC),
+               @test Pipeline(m, t, u, i, u) isa DeterministicPipeline)
+
+    # if "hidden" supervised model is already deterministic,
+    # no need for warning:
+    @test_logs @test Pipeline(m, t, u, d, u) isa DeterministicPipeline
+
+    # named components:
+    @test Pipeline(c1=m, c2=t, c3=u) isa UnsupervisedPipeline
+    @test Pipeline(c1=m, c2=t, c3=u, c5=p) isa ProbabilisticPipeline
+    @test Pipeline(c1=m, c2=t) isa StaticPipeline
+    @test Pipeline(c1=m, c2=t, c6=s) isa StaticPipeline
+    @test Pipeline(c1=m, c2=t, c6=s, c7=d) isa DeterministicPipeline
+    @test Pipeline(c1=m, c2=t, c8=i) isa IntervalPipeline
+    @test_logs((:info, MLJBase.INFO_TREATING_AS_DETERMINISTIC),
+               @test Pipeline(c1=m, c2=t, c3=u, c5=p, c4=u) isa
+               DeterministicPipeline)
+    @test(Pipeline(c1=m, c2=t, c3=u, c5=p, c4=u, prediction_type=:interval) isa
+          IntervalPipeline)
+    @test(Pipeline(c1=m, c2=t, c3=u, c5=p, c4=u,
+                   prediction_type=:probabilistic) isa
+          ProbabilisticPipeline)
+    @test_logs((:info, MLJBase.INFO_TREATING_AS_DETERMINISTIC),
+               @test Pipeline(c1=m, c2=t, c3=u, c8=i, c4=u) isa
+               DeterministicPipeline)
+    # if "hidden" supervised model is already deterministic,
+    # no need for warning:
+    @test_logs(@test Pipeline(c1=m, c2=t, c3=u, c7=d, c4=u) isa
+               DeterministicPipeline)
+
+    # errors and warnings:
+    @test_throws MLJBase.ERR_MIXED_PIPELINE_SPEC Pipeline(m, mymodel=p)
+    @test_throws(MLJBase.ERR_INVALID_OPERATION,
+                 Pipeline(u, s, operation=cos))
+    @test_throws(MLJBase.ERR_INVALID_PREDICTION_TYPE,
+                 Pipeline(u=u, s=s, prediction_type=:ostrich))
+    @test_logs((:warn, MLJBase.WARN_IGNORING_PREDICTION_TYPE),
+               Pipeline(m, t, u, prediction_type=:deterministic))
+
+end
+
+@testset "property access" begin
+    pipe = Pipeline(m, u, u, s)
+
+    # property names:
+    @test propertynames(pipe) ===
+        (:f, :my_unsupervised, :my_unsupervised2, :my_transformer2, :cache)
+
+    # getindex:
+    pipe.my_unsupervised == u
+    pipe.my_unsupervised2 == u
+    pipe.cache = true
+
+    # replacing a component with one whose abstract supertype is the same
+    # or smaller:
+    pipe.my_unsupervised = s
+    @test pipe.my_unsupervised == s
+
+    # attempting to replace a component with one whose abstract supertype
+    # is bigger:
+    @test_throws MethodError pipe.my_transformer2 = u
+
+    # mutating the components themeselves:
+    pipe.my_unsupervised.ftr = :z
+    @test pipe.my_unsupervised.ftr == :z
+
+    # or using MLJBase's recursive getproperty:
+    MLJBase.recursive_setproperty!(pipe, :(my_unsupervised.ftr), :bonzai)
+    @test pipe.my_unsupervised.ftr ==  :bonzai
+end
+
+@testset "show" begin
+    io = IOBuffer()
+    pipe = Pipeline(x-> x^2, m, t, p)
+    show(io, MIME("text/plain"), pipe)
+end
+
+end
+
+true

--- a/test/composition/models/pipelines2.jl
+++ b/test/composition/models/pipelines2.jl
@@ -440,5 +440,48 @@ end
     @test isapprox(x, x̂)
 end
 
+@testset "syntactic sugar" begin
+
+    # recall u, s, p, m, are defined way above
+
+    # unsupervised model |> static model:
+    pipe1 = u |> s
+    @test pipe1 == Pipeline(u, s)
+
+    # unsupervised model |> supervised model:
+    pipe2 = u |> p
+    @test pipe2 == Pipeline(u, p)
+
+    # pipe |> pipe:
+    hose = pipe1 |> pipe2
+    @test hose == Pipeline(u, s, u, p)
+
+    # pipe |> model:
+    @test Pipeline(u, s) |> p == Pipeline(u, s, p)
+
+    # model |> pipe:
+    @test u |> Pipeline(s, p) == Pipeline(u, s, p)
+
+    # pipe |> function:
+    @test Pipeline(u, s) |> m == Pipeline(u, s, m)
+
+    # function |> pipe:
+    @test m |> Pipeline(s, p) == Pipeline(m, s, p)
+
+    # model |> function:
+    @test u |> m == Pipeline(u, m)
+
+    # function |> model:
+    @test t |> u == Pipeline(t, u)
+
+    @test_logs((:info, MLJBase.INFO_AMBIGUOUS_CACHE),
+               Pipeline(u, cache=false) |> p)
+
+    # with types
+    @test PCA |> Standardizer() |> KNNRegressor ==
+        Pipeline(PCA(), Standardizer(), KNNRegressor())
 end
+
+end
+
 true

--- a/test/composition/models/pipelines2.jl
+++ b/test/composition/models/pipelines2.jl
@@ -460,7 +460,7 @@ MLJBase.transform(model::DummyClusterer, fitresult, Xnew) =
 MLJBase.predict(model::DummyClusterer, fitresult, Xnew) =
     [fill(fitresult[1], nrows(Xnew))...]
 
-@test "integration 8" begin
+@testset "integration 8" begin
     # calling predict on unsupervised pipeline
     # https://github.com/JuliaAI/MLJClusteringInterface.jl/issues/10
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -84,8 +84,8 @@ end
     @test include("composition/learning_networks/nodes.jl")
     @test include("composition/learning_networks/inspection.jl")
     @test include("composition/learning_networks/machines.jl")
-    VERSION ≥ v"1.3.0-" &&
-        @test include("composition/learning_networks/arrows.jl")
+    # VERSION ≥ v"1.3.0-" &&
+    #     @test include("composition/learning_networks/arrows.jl")
 end
 
 @testset "composition - models" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -93,6 +93,7 @@ end
     @test include("composition/models/from_network.jl")
     @test include("composition/models/inspection.jl")
     @test include("composition/models/pipelines.jl")
+    @test include("composition/models/pipelines2.jl")
     @test include("composition/models/stacking.jl")
     @test include("composition/models/_wrapped_function.jl")
     @test include("composition/models/static_transformers.jl")

--- a/test/sources.jl
+++ b/test/sources.jl
@@ -14,5 +14,8 @@ rebind!(Xs, nothing)
 @test isempty(Xs)
 @test Xs.scitype == Nothing
 
+n = MLJBase.ErrorNode(ArgumentError("Stop!"))
+@test_throws ArgumentError("Stop!") n(rows=1:3)
+
 end
 true

--- a/test/sources.jl
+++ b/test/sources.jl
@@ -16,6 +16,7 @@ rebind!(Xs, nothing)
 
 n = MLJBase.ErrorNode(ArgumentError("Stop!"))
 @test_throws ArgumentError("Stop!") n(rows=1:3)
+@test_throws ArgumentError("Stop!") n(1:3)
 
 end
 true

--- a/test/utilities.jl
+++ b/test/utilities.jl
@@ -66,7 +66,7 @@ end
 
     x = 1:5 |> collect
     y = 1:5 |> collect
-    
+
     # In the following tests it is crucial to recreate a new `RNG` each time.
     perm = Random.randperm(StableRNG(11900), 5)
     @test MLJBase.shuffle_rows(x, y; rng=StableRNG(11900)) == (x[perm], y[perm])
@@ -127,6 +127,32 @@ end
     @test MLJBase.available_name(Utilities, :orange) == :orange2
     Utilities.eval(:(orange2 = 6))
     @test MLJBase.available_name(Utilities, :orange) == :orange3
+end
+
+@testset "generate_name!" begin
+    existing_names = Symbol[]
+    @test MLJBase.generate_name!(Vector{Int}, existing_names) ==
+        :vector
+    @test MLJBase.generate_name!(Vector{Float64}, existing_names) ==
+        :vector2
+    @test MLJBase.generate_name!(Vector{Float64},
+                                 existing_names,
+                                 only=Number) == :f
+    @test MLJBase.generate_name!(Vector{Float64},
+                                 existing_names,
+                                 only=Number) == :f2
+    @test MLJBase.generate_name!(Vector{Float64},
+                                 existing_names,
+                                 only=Number,
+                                 substitute=:g) == :g
+    @test MLJBase.generate_name!(Vector{Float64},
+                                 existing_names,
+                                 only=Number,
+                                 substitute=:g) == :g2
+    @test existing_names == [:vector, :vector2, :f, :f2, :g, :g2]
+
+    @test MLJBase.generate_name!(42, [], only=Array) == :f
+    @test MLJBase.generate_name!(42, [], only=Number, substitute=:g) == :int64
 end
 
 end # module


### PR DESCRIPTION
This PR is a step towards replacement of `@pipeline` with non-macro alternatives (https://github.com/alan-turing-institute/MLJ.jl/issues/594). It implements new parametric types for pipelines and a new constructor `Pipeline`, following the suggestions of @CameronBieganek in the cited issue.

The new pipelines offer all the features of @pipeline with the exception of target transformations, which are to be [provided with a separate wrapper](https://github.com/alan-turing-institute/MLJ.jl/issues/594#issuecomment-751863495). Additional features are:

- `inverse_transform` is implemented, where that makes sense (there was an issue raised, which I cannot find)
- implement `predict` for unsupervised pipelines ending in a model that implements `predict` (clustering) (https://github.com/JuliaAI/MLJClusteringInterface.jl/issues/10)
- Alternative constructor using `|>`. When two pipelines are concatenated, the result is flat (does not introduce an extra layer of hyper-parameter nesting).

The new doc-string is copied below under "details".

### Conflict with existing feature

The overloading of `|>` conflicts with the "arrow syntax" described [here](https://juliaai.github.io/DataScienceTutorials.jl/getting-started/learning-networks/#arrow_syntax) but never actually documented in the manual. It's purpose is to reduce code needed to build learning networks. I have not seen it used anywhere outside of the cited tutorial and would suggest linear pipelines, as a more common use-case, would be a better use. A non-breaking alternative would be to overload the generic associative operator `*`. 

What do others think?

<details>

    Pipeline(component1, component2, ... , componentk; options...)
    Pipeline(name1=component1, name2=component2, ..., componentk; options...)
    component1 |> component2 |> ... |> componentk

Create an instance of composite model type which sequentially composes
the specified components in order. This means `component1` receives
inputs, whose output is passed to `component2`, and so forth. A
"component" is either a `Model` instance, a model type (converted
immediately to its default instance) or any callable object.

At most one of the components may be a supervised model, but this
model can appear in any position.

The `@pipeline` macro accepts key-word `options` discussed further
below.

Ordinary functions (and other callables) may be inserted in the
pipeline as shown in the following example:

    Pipeline(X->coerce(X, :age=>Continuous), OneHotEncoder, ConstantClassifier)

### Syntactic sugar

The `|>` operator is overloaded to construct pipelines out of models,
functions, and existing pipelines:

```julia
LinearRegressor = @load LinearRegressor pkg=MLJLinearModels add=true
PCA = @load PCA pkg=MultivariateStats add=true

pipe1 = MLJBase.table |> ContinuousEncoder |> Standardizer
pipe2 = PCA |> LinearRegressor
pipe1 |> pipe2
```

### Special operations

If all the `components` are invertible unsupervised models
(transformers), then `inverse_transform` is implemented for the
pipeline. If there are no supervised models, then `predict` is
nevertheless implemented, assuming the last model (such as `KMeans`
clustering) also implements it. Similarly, calling `transform` on a
supervised pipeline calls `transform` on the supervised component.

### Optional key-word arguments

- `prediction_type`  -
  prediction type of the pipeline; possible values: `:deterministic`,
  `:probabilistic`, `:interval` (default=`:deterministic` if not inferable)

- `operation` - operation applied to the supervised component model,
  when present; possible values: `predict`, `predict_mean`,
  `predict_median`, `predict_mode` (default=`predict`)

- `cache` - whether the internal machines created for component models
  should cache model-specific representations of data. See [`machine`](@ref).

!!! warning "Set `cache=false` to guarantee data anonymization"

    This precaution applies to composite models, and only to those
    implemented using learning networks.

To build more complicated non-branching pipelines, refer to the MLJ
manual sections on composing models.

</details>

@CameronBieganek Any depth of review here would be greatly appreciated. 