### PR TITLE
Display tweaks

### DIFF
--- a/src/hyperparam/one_dimensional_ranges.jl
+++ b/src/hyperparam/one_dimensional_ranges.jl
@@ -1,6 +1,6 @@
 ## PARAMETER RANGES
 
-abstract type ParamRange{T} <: MLJType end
+abstract type ParamRange{T} end
 
 Base.isempty(::ParamRange) = false
 
@@ -28,14 +28,28 @@ struct NominalRange{T,N} <: ParamRange{T}
 end
 
 function Base.show(stream::IO,
-                   ::MIME"text/plain",
-                   r::ParamRange{T}) where T
-    if r.field isa Expr
-        fstr = ":($(r.field))"
+#                   ::MIME"text/plain",
+                   r::NumericRange{T}) where T
+    fstr = string(r.field)
+    repr = "NumericRange($(r.lower) ≤ $fstr ≤ $(r.upper); "*
+        "origin=$(r.origin), unit=$(r.unit))"
+    if r.scale isa Symbol
+        r.scale !== :linear && (repr *= " on $(r.scale) scale")
     else
-        fstr = ":$(r.field)"
+        repr *= " on non-linear scale"
     end
-    repr = "$(typeof(r).name)($T, $fstr, ... )"
+    print(stream, repr)
+    return nothing
+end
+
+function Base.show(stream::IO,
+#                   ::MIME"text/plain",
+                   r::NominalRange{T}) where T
+    fstr = string(r.field)
+    values_str = join(string.(r.values), ", ")
+    suffix = length(r.values) > 3 ? ", ..." : ""
+    values_str *= suffix
+    repr = "NominalRange($fstr = $values_str)"
     print(stream, repr)
     return nothing
 end

--- a/src/resampling.jl
+++ b/src/resampling.jl
@@ -469,9 +469,12 @@ function Base.show(io::IO, ::MIME"text/plain", e::PerformanceEvaluation)
             "  per_observation, fitted_params_per_fold,\n"*
             "  report_per_fold, train_test_pairs")
     println(io, "Extract:")
+    show_color = MLJBase.SHOW_COLOR
+    color_off()
     PrettyTables.pretty_table(io, data, header;
                               header_crayon=PrettyTables.Crayon(bold=false),
                               alignment=:l)
+    show_color ? color_on() : color_off()
 end
 
 function Base.show(io::IO, e::PerformanceEvaluation)

--- a/src/show.jl
+++ b/src/show.jl
@@ -114,6 +114,7 @@ show_compact(::Type) = false
 
 show_as_constructed(object) = show_as_constructed(typeof(object))
 show_compact(object) = show_compact(typeof(object))
+show_handle(object) = false
 
 # simplified string rep of an Type:
 function simple_repr(T)
@@ -137,9 +138,9 @@ end
 
 # short version of showing a `MLJType` object:
 function Base.show(stream::IO, object::MLJType)
-    repr = simple_repr(typeof(object))
-    str = "$repr $(handle(object))"
-    if !isempty(propertynames(object))
+    str = simple_repr(typeof(object))
+    show_handle(object) && (str *= " $(handle(object))")
+    if false # !isempty(propertynames(object))
         printstyled(IOContext(stream, :color=> SHOW_COLOR),
                     str, bold=false, color=:blue)
     else
@@ -189,7 +190,7 @@ function fancy(stream, object::MLJType, current_depth, depth, n)
             k == n_names || print(stream, ",")
         end
         print(stream, ")")
-        if current_depth == 0
+        if current_depth == 0 && show_handle(object)
             description = " $(handle(object))"
             printstyled(IOContext(stream, :color=> SHOW_COLOR),
                         description, bold=false, color=:blue)

--- a/src/sources.jl
+++ b/src/sources.jl
@@ -115,12 +115,17 @@ origins(s::Source) = [s,]
 
 # show within other objects:
 function Base.show(stream::IO, object::AbstractNode)
-    repr = simple_repr(typeof(object))
-    str = "$repr $(handle(object))"
-    printstyled(IOContext(stream, :color=> SHOW_COLOR),
+    str = simple_repr(typeof(object))
+    show_handle(object) && (str *= " $(handle(object))")
+    if false
+        printstyled(IOContext(stream, :color=> SHOW_COLOR),
                     str, bold=false, color=:blue)
+    else
+        print(stream, str)
+    end
     return nothing
 end
+show_handle(::Source) = true
 
 # show when alone:
 function Base.show(stream::IO, ::MIME"text/plain", source::Source)
@@ -128,4 +133,3 @@ function Base.show(stream::IO, ::MIME"text/plain", source::Source)
     print(stream, " \u23CE `$(elscitype(source))`")
     return nothing
 end
-

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -178,6 +178,8 @@ function init_rng(rng)
     end
     return rng
 end
+
+
 ## FOR PRETTY PRINTING
 
 # of coloumns:

--- a/test/measures/measures.jl
+++ b/test/measures/measures.jl
@@ -119,6 +119,7 @@ include("loss_functions_interface.jl")
     for meta in measures()
         m = eval(Meta.parse("$(meta.name)()"))
         show(io, MIME("text/plain"), m)
+        show(io, m)
     end
 end
 


### PR DESCRIPTION
This PR carries out some tweaks to the way MLJBase displays objects:

- suppress `@423` business except for source nodes (https://github.com/alan-turing-institute/MLJ.jl/issues/842)
- suppress blue colouring of objects (leave some bold)
- fix some extraneous characters appearing in evaluation objects 
- #532 