### PR TITLE
Fix input checks for unsupervised annotators

### DIFF
--- a/src/machines.jl
+++ b/src/machines.jl
@@ -117,22 +117,7 @@ err_length_mismatch(model::Supervised) = DimensionMismatch(
 check(model::Any, args...; kwargs...) =
     throw(ArgumentError("Expected a `Model` instance, got $model. "))
 
-function check(model::Model, args...; full=false)
-
-    nowarns = true
-
-    F = fit_data_scitype(model)
-    (F >: Unknown || F >: Tuple{Unknown} || F >: NTuple{<:Any,Unknown}) &&
-        return true
-
-    S = Tuple{elscitype.(args)...}
-    if !(S <: F)
-        @warn warn_generic_scitype_mismatch(S, F)
-        nowarns = false
-    end
-end
-
-function check_supervised(model, args...; full)
+function check_supervised(model, full, args...)
     nowarns = true
 
     nargs = length(args)
@@ -164,7 +149,7 @@ function check_supervised(model, args...; full)
 
 end
 
-function check_unsupervised(model, args...; full)
+function check_unsupervised(model, full, args...)
     nowarns = true
 
     nargs = length(args)
@@ -182,19 +167,33 @@ function check_unsupervised(model, args...; full)
     return nowarns
 end
 
-function check(model::Union{Supervised, SupervisedAnnotator}, args... ; full=false)
-    check_supervised(model, args...; full)
+function check(model::Model, args...; full=false)
+    nowarns = true
+
+    F = fit_data_scitype(model)
+    (F >: Unknown || F >: Tuple{Unknown} || F >: NTuple{<:Any,Unknown}) &&
+        return true
+
+    S = Tuple{elscitype.(args)...}
+    if !(S <: F)
+        @warn warn_generic_scitype_mismatch(S, F)
+        nowarns = false
+    end
+end
+
+function check(model::Union{Supervised, SupervisedAnnotator}, args... ; full = false)
+    check_supervised(model, full, args...)
 end
 
 function check(model::Unsupervised, args...; full=false)
-    check_unsupervised(model, args...; full)
+    check_unsupervised(model, full, args...)
 end
 
 function check(model::UnsupervisedAnnotator, args... ; full = false)
     if length(args) <= 1
-        check_unsupervised(model, args...; full)
+        check_unsupervised(model, full, args...)
     else
-        check_supervised(model, args...; full)
+        check_supervised(model, full, args...)
     end
 end
 

--- a/src/machines.jl
+++ b/src/machines.jl
@@ -132,8 +132,7 @@ function check(model::Model, args...; full=false)
     end
 end
 
-function check(model::Supervised, args... ; full=false)
-
+function check_supervised(model, args...; full)
     nowarns = true
 
     nargs = length(args)
@@ -165,7 +164,7 @@ function check(model::Supervised, args... ; full=false)
 
 end
 
-function check(model::Unsupervised, args...; full=false)
+function check_unsupervised(model, args...; full)
     nowarns = true
 
     nargs = length(args)
@@ -183,7 +182,21 @@ function check(model::Unsupervised, args...; full=false)
     return nowarns
 end
 
+function check(model::Union{Supervised, SupervisedAnnotator}, args... ; full=false)
+    check_supervised(model, args...; full)
+end
 
+function check(model::Unsupervised, args...; full=false)
+    check_unsupervised(model, args...; full)
+end
+
+function check(model::UnsupervisedAnnotator, args... ; full = false)
+    if length(args) <= 1
+        check_unsupervised(model, args...; full)
+    else
+        check_supervised(model, args...; full)
+    end
+end
 
 """
     machine(model, args...; cache=true)


### PR DESCRIPTION
Unsupervised annotators can be called in both a supervised and unsupervised fashion.