### PR TITLE
Extend overloading of `predict_mode`, etc to all models, not just `Supervised`

### DIFF
--- a/src/interface/model_api.jl
+++ b/src/interface/model_api.jl
@@ -8,11 +8,11 @@ const err_wrong_target_scitype(actual_scitype) = ArgumentError(
     "by a model with `$actual_scitype` targets. ")
 
 # mode:
-predict_mode(m::Probabilistic, fitresult, Xnew) =
+predict_mode(m, fitresult, Xnew) =
     mode.(predict(m, fitresult, Xnew))
 
 # mean:
-predict_mean(m::Probabilistic, fitresult, Xnew) =
+predict_mean(m, fitresult, Xnew) =
     predict_mean(m, fitresult, Xnew, target_scitype(m))
 predict_mean(m, fitresult, Xnew, ::Any) =
     mean.(predict(m, fitresult, Xnew))
@@ -20,7 +20,7 @@ predict_mean(m, fitresult, Xnew, ::Type{<:BadMeanTypes}) =
     throw(err_wrong_target_scitype(Finite))
 
 # median:
-predict_median(m::Probabilistic, fitresult, Xnew) =
+predict_median(m, fitresult, Xnew) =
     predict_median(m, fitresult, Xnew, target_scitype(m))
 predict_median(m, fitresult, Xnew, ::Any) =
     median.(predict(m, fitresult, Xnew))

--- a/test/interface/model_api.jl
+++ b/test/interface/model_api.jl
@@ -17,14 +17,16 @@ rng = StableRNG(661)
     clf = ConstantClassifier()
     fitresult, _, _ = MLJBase.fit(clf, 1, X, yfinite)
     @test predict_mode(clf, fitresult, X)[1] == 'a'
-    @test_throws ArgumentError predict_mean(clf, fitresult, X)
-    @test_throws ArgumentError predict_median(clf, fitresult, X)
+    @test_throws(MLJBase.err_wrong_target_scitype(MLJBase.Finite),
+                 predict_mean(clf, fitresult, X))
+    @test_throws(MLJBase.err_wrong_target_scitype(MLJBase.Finite),
+                 predict_median(clf, fitresult, X))
 
     rgs = ConstantRegressor()
     fitresult, _, _ = MLJBase.fit(rgs, 1, X, ycont)
     @test predict_mean(rgs, fitresult, X)[1] == 3
     @test predict_median(rgs, fitresult, X)[1] == 3
-    @test_throws ArgumentError predict_mode(rgs, fitresult, X)
+    @test predict_mode(rgs, fitresult, X)[1] == 3
 end
 
 mutable struct UnivariateFiniteFitter <: MLJModelInterface.Probabilistic


### PR DESCRIPTION
Resolves first part of  #656.

Used to throw an error:

```julia
using MLJ
model = (@load GMMClusterer)()
X, _ = make_moons()
mach = machine(model, X) |> fit!
julia> predict_mode(mach, rows=1:2)
2-element CategoricalArrays.CategoricalArray{Int64,1,UInt32}:
 2
 1
```

cc @juliohm 

