### PR TITLE
Allow automatic access to `training_losses` in iterative models wrapped in a pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
     branches:
       - master
       - dev
-      - for-a-0-point-19-release
+      - for-0-point-19-release
   push:
     branches:
       - master

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on:
     branches:
       - master
       - dev
+      - for-a-0-point-19-release
   push:
     branches:
       - master

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -47,6 +47,24 @@ function reduce_nested_field(ex)
 end
 
 """
+    prepend(s::Symbol, s::Symbol)
+
+For prepending symbols in expressions like `:(y.w)` and `:(x1.x2.x3)`.
+
+julia> compose(:x, :y)
+:(x.y)
+
+julia> compose(:x, :(y.z))
+:(x.y.z)
+
+julia> compose(:w, ans)
+:(w.x.y.z)
+
+"""
+prepend(s::Symbol, t::Symbol) = Expr(:(.), s, QuoteNode(t))
+prepend(s::Symbol, ex::Expr) = Expr(:(.), prepend(s, ex.args[1]), ex.args[2])
+
+"""
     recursive_getproperty(object, nested_name::Expr)
 
 Call getproperty recursively on `object` to extract the value of some

--- a/test/utilities.jl
+++ b/test/utilities.jl
@@ -36,6 +36,10 @@ mutable struct A21
     a212
 end
 
+@testset "prepend" begin
+    MLJBase.prepend(:x, :(y.z.w)) == :(x.y.z.w)
+end
+
 @testset "recursive getproperty, setproperty!" begin
     m = (a1 = (a11 = 10, a12 = 20), a2 = (a21 = (a211 = 30, a212 = 40),))
 


### PR DESCRIPTION
Previously this didn't' work:

```julia
model = NeuralNetworkClassifier
pipe = Standardizer() |> model
mach = machine(pipe, (@load_iris)...) |> fit!

julia> training_losses(mach)
10-element Vector{Float64}:
 1.1617235772453105
 1.1391298992309888
 1.1353015649469138
 1.118214804032455
 1.0628404657351944
 1.0259886932644746
 1.0157579569196977
 0.9370889236524335
 0.9723838495187639
 0.9687408965584012
```

Also, the pipeline now knows the iteration parameter, which is now nested:

```julia
julia> iteration_parameter(pipe)
:(neural_network_classifier.epochs)
```

Which means pipelines play nicely with `IteratedModel`. 