### PR TITLE
Add R-square (coefficient of determination)

### DIFF
--- a/src/MLJBase.jl
+++ b/src/MLJBase.jl
@@ -186,7 +186,8 @@ export mav, mae, mape, rms, rmsl, rmslp1, rmsp, l1, l2, log_cosh,
     RMS, rmse, RootMeanSquaredError, root_mean_squared_error,
     RootMeanSquaredLogError, RMSL, root_mean_squared_log_error, rmsl, rmsle,
     RootMeanSquaredLogProportionalError, rmsl1, RMSLP,
-    MAPE, MeanAbsoluteProportionalError, log_cosh_loss, LogCosh, LogCoshLoss
+    MAPE, MeanAbsoluteProportionalError, log_cosh_loss, LogCosh, LogCoshLoss,
+    RSquared, rsq, rsquared
 
 # measures/confusion_matrix.jl:
 export confusion_matrix, confmat, ConfusionMatrix

--- a/src/measures/continuous.jl
+++ b/src/measures/continuous.jl
@@ -77,8 +77,7 @@ metadata_measure(RSquared;
     instances               = ["rsq", "rsquared"],
     target_scitype          = InfiniteArrMissing,
     prediction_type         = :deterministic,
-    orientation             = :loss,
-    aggregation             = RSquared()
+    orientation             = :loss
 )
 
 const RSQ = RSquared

--- a/src/measures/continuous.jl
+++ b/src/measures/continuous.jl
@@ -69,6 +69,8 @@ call(::RootMeanSquaredError,
 # -------------------------------------------------------------------------
 # R-squared (coefficient of determination)
 
+foo(x) = x
+
 struct RSquared <: Aggregated end
 
 metadata_measure(RSquared;
@@ -91,11 +93,21 @@ This is because R² is a percentage whereas MSE and RMSE have arbitrary ranges.
 Let ``\\overline{y}`` denote the mean of ``y``, then
 
 ``\\text{R^2} = 1 - \\frac{∑ (\\hat{y} - y)^2}{∑ \\overline{y} - y)^2}.``
-""",
-footer="")
+""")
 
 function call(::RSquared, ŷ::ArrMissing{<:Real}, y::ArrMissing{<:Real})
     num = (ŷ .- y).^2 |> skipinvalid |> sum
+    mean_y = mean(y)
+    denom = (mean_y .- y).^2 |> skipinvalid |> sum
+    return 1 - (num / denom)
+end
+
+function call(::RSquared,
+        ŷ::ArrMissing{<:Real},
+        y::ArrMissing{<:Real},
+        w::Arr{<:Real}
+    )
+    num = (ŷ .- y).^2 .* w |> skipinvalid |> sum
     mean_y = mean(y)
     denom = (mean_y .- y).^2 |> skipinvalid |> sum
     return 1 - (num / denom)

--- a/src/measures/continuous.jl
+++ b/src/measures/continuous.jl
@@ -69,8 +69,6 @@ call(::RootMeanSquaredError,
 # -------------------------------------------------------------------------
 # R-squared (coefficient of determination)
 
-foo(x) = x
-
 struct RSquared <: Aggregated end
 
 metadata_measure(RSquared;
@@ -108,7 +106,7 @@ function call(::RSquared,
     )
     num = (ŷ .- y).^2 .* w |> skipinvalid |> sum
     mean_y = mean(y)
-    denom = (mean_y .- y).^2 |> skipinvalid |> sum
+    denom = (mean_y .- y).^2 .* w |> skipinvalid |> sum
     return 1 - (num / denom)
 end
 

--- a/src/measures/continuous.jl
+++ b/src/measures/continuous.jl
@@ -75,8 +75,7 @@ metadata_measure(RSquared;
     instances               = ["rsq", "rsquared"],
     target_scitype          = InfiniteArrMissing,
     prediction_type         = :deterministic,
-    orientation             = :loss
-)
+    orientation             = :score)
 
 const RSQ = RSquared
 @create_aliases RSquared
@@ -84,8 +83,7 @@ const RSQ = RSquared
 @create_docs(RSquared,
 body=
 """
-The R² (also known as R-squared or coefficient of determination) is very suitable for interpreting regression analysis (Chicco et al., [2021](https://doi.org/10.7717/peerj-cs.623)).
-This is because R² is a percentage whereas MSE and RMSE have arbitrary ranges.
+The R² (also known as R-squared or coefficient of determination) is suitable for interpreting linear regression analysis (Chicco et al., [2021](https://doi.org/10.7717/peerj-cs.623)).
 
 Let ``\\overline{y}`` denote the mean of ``y``, then
 
@@ -96,17 +94,6 @@ function call(::RSquared, ŷ::ArrMissing{<:Real}, y::ArrMissing{<:Real})
     num = (ŷ .- y).^2 |> skipinvalid |> sum
     mean_y = mean(y)
     denom = (mean_y .- y).^2 |> skipinvalid |> sum
-    return 1 - (num / denom)
-end
-
-function call(::RSquared,
-        ŷ::ArrMissing{<:Real},
-        y::ArrMissing{<:Real},
-        w::Arr{<:Real}
-    )
-    num = (ŷ .- y).^2 .* w |> skipinvalid |> sum
-    mean_y = mean(y)
-    denom = (mean_y .- y).^2 .* w |> skipinvalid |> sum
     return 1 - (num / denom)
 end
 

--- a/test/measures/continuous.jl
+++ b/test/measures/continuous.jl
@@ -11,6 +11,7 @@ rng = StableRNG(666899)
     @test isapprox(mae(yhat, y, w), (1*3 + 2*1 + 4*1 + 3*3)/4)
     @test isapprox(rms(yhat, y), sqrt(5))
     @test isapprox(rms(yhat, y, w), sqrt((1*3^2 + 2*1^2 + 4*1^2 + 3*3^2)/4))
+    @test rsq(yhat, y) == -3
     @test isapprox(mean(skipinvalid(l1(yhat, y))), 2)
     @test isapprox(mean(skipinvalid(l1(yhat, y, w))), mae(yhat, y, w))
     @test isapprox(mean(skipinvalid(l2(yhat, y))), 5)

--- a/test/resampling.jl
+++ b/test/resampling.jl
@@ -359,7 +359,7 @@ end
     for cache in [true, false]
         model = Models.DeterministicConstantRegressor()
         mach = machine(model, X, y, cache=cache)
-        result = evaluate!(mach, resampling=cv, measure=[rms, rmslp1],
+        result = evaluate!(mach, resampling=cv, measure=[rms, rsq, rmslp1],
                            acceleration=accel, verbosity=verb)
 
         @test result.per_fold[1] ≈ [1/2, 3/4, 1/2, 3/4, 1/2]

--- a/test/resampling.jl
+++ b/test/resampling.jl
@@ -105,7 +105,7 @@ MLJBase.prediction_type(::typeof(dummy_measure_interval)) = :interval
 end
 
 @testset "_feature_dependencies_exist" begin
-    measures = Any[rms, log_loss, brier_score]
+    measures = Any[rms, rsq, log_loss, brier_score]
     @test !MLJBase._feature_dependencies_exist(measures)
     my_feature_dependent_loss(ŷ, X, y) =
         sum(abs.(ŷ - y) .* X.penalty)/sum(X.penalty);

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,7 +5,7 @@ using MLJBase
 if !MLJBase.TESTING
     error("To test MLJBase, the environment variable "*
           "`TEST_MLJBASE` must be set to `\"true\"`\n"*
-          "You can do this in the REPL with `ENV[\"TEST_MLJBASE\"]=\"true\"")
+          "You can do this in the REPL with `ENV[\"TEST_MLJBASE\"]=\"true\"`")
 end
 
 @info "nprocs() = $(nprocs())"


### PR DESCRIPTION
This PR adds the R² metric.

R² is more informative for linear regressions than MSE and RMSE (Chicco et al, [2021](https://doi.org/10.7717/peerj-cs.623)) because the scale is dimensionless (a percentage).

I value -3 in the test is manually calculated by me. All looks good.

EDIT: It doesn't work yet in CV. I get an `_check(::RSquare, Vector{Int})`. I'll debug it tonight or so