### PR TITLE
Allow `target` to be a model *type* in `TransformedTargetModel`

### DIFF
--- a/src/machines.jl
+++ b/src/machines.jl
@@ -356,7 +356,7 @@ machines(::Source) = Machine[]
 _cache_status(::Machine{<:Any,true}) = " caches data"
 _cache_status(::Machine{<:Any,false}) = " does not cache data"
 
-function Base.show(io::IO, ::MIME"text/plain", mach::Machine)
+function Base.show(io::IO, ::MIME"text/plain", mach::Machine{M}) where M
     show(io, mach)
     print(io, " trained $(mach.state) time")
     if mach.state == 1
@@ -365,6 +365,7 @@ function Base.show(io::IO, ::MIME"text/plain", mach::Machine)
         print(io, "s;")
     end
     println(io, _cache_status(mach))
+    println(io, "  model: $M")
     println(io, "  args: ")
     for i in eachindex(mach.args)
         arg = mach.args[i]

--- a/test/composition/models/transformed_target_model.jl
+++ b/test/composition/models/transformed_target_model.jl
@@ -14,6 +14,8 @@ whitener = UnivariateStandardizer()
 
 @testset "constructor and clean!" begin
 
+    @test_logs TransformedTargetModel(atom,
+                                              target=UnivariateStandardizer)
     model = @test_logs TransformedTargetModel(atom, target=whitener)
     @test model.model == atom
     @test model.inverse == nothing


### PR DESCRIPTION
If a type is provided then `fit` changes this to the default instance.

Otherwise a warning is issued, which is not that helpful to realize one's mistake.