### PR TITLE
extend MLJModelInterface.scitype method

### DIFF
--- a/src/MLJBase.jl
+++ b/src/MLJBase.jl
@@ -22,8 +22,8 @@ import StatisticalTraits.info
 
 # Interface
 
-# HACK: When https://github.com/JuliaAI/MLJModelInterface.jl/issues/124
-# is resolved:
+# HACK: When https://github.com/JuliaAI/MLJModelInterface.jl/issues/124 and
+# https://github.com/JuliaAI/MLJModelInterface.jl/issues/131 is resolved:
 # Uncomment next line and delete "Hack Block"
 # using MLJModelInterface
 #####################
@@ -34,9 +34,12 @@ exported_names(m::Module) =
             Base.names(m; all=true, imported=true))
 import MLJModelInterface
 for name in exported_names(MLJModelInterface)
-    name in [:UnivariateFinite,
-             :augmented_transform,
-             :info] && continue
+    name in [
+        :UnivariateFinite,
+        :augmented_transform,
+        :info,
+        :scitype # Needed to avoid clashing with `ScientificTypes.scitype` 
+    ] && continue
     quote
         import MLJModelInterface.$name
     end |> eval

--- a/src/interface/data_utils.jl
+++ b/src/interface/data_utils.jl
@@ -19,10 +19,17 @@ MMI.int(::FI, x; args...) = CategoricalDistributions.int(x; args...)
 MMI.classes(::FI, x) = CategoricalDistributions.classes(x)
 
 # ------------------------------------------------------------------------
-# `schema`
-function MMI.schema(::FI, ::Union{Val{:other}, Val{:table}}, X; kw...)
-    return schema(X; kw...)
+# `scitype`
+function MMI.scitype(::FI, ::Union{Val{:other}, Val{:table}}, X)
+    return ScientificTypes.scitype(X)
 end
+
+# ------------------------------------------------------------------------
+# `schema`
+function MMI.schema(::FI, ::Union{Val{:other}, Val{:table}}, X)
+    return ScientificTypes.schema(X)
+end
+
 # ------------------------------------------------------------------------
 # decoder
 

--- a/test/interface/data_utils.jl
+++ b/test/interface/data_utils.jl
@@ -14,6 +14,35 @@ end
     @test classes(v) == levels(v)
 end
 
+@testset "MLJModelInterface.scitype overload" begin
+    ST = MLJBase.ScientificTypes
+    x = rand(Int, 3)
+    y = rand(Int, 2, 3)
+    z = rand(3)
+    a = rand(4, 3)
+    b = categorical(["a", "b", "c"])
+    c = categorical(["a", "b", "c"]; ordered=true)
+    X = (x1=x, x2=z, x3=b, x4=c)
+    @test MLJModelInterface.scitype(x) == ST.scitype(x)    
+    @test MLJModelInterface.scitype(y) == ST.scitype(y)
+    @test MLJModelInterface.scitype(z) == ST.scitype(z)
+    @test MLJModelInterface.scitype(a) == ST.scitype(a)
+    @test MLJModelInterface.scitype(b) == ST.scitype(b)
+    @test MLJModelInterface.scitype(c) == ST.scitype(c)
+    @test MLJModelInterface.scitype(X) == ST.scitype(X)
+end
+
+@testset "MLJModelInterface.schema overload" begin
+    ST = MLJBase.ScientificTypes
+    x = rand(Int, 3)
+    z = rand(3)
+    b = categorical(["a", "b", "c"])
+    c = categorical(["a", "b", "c"]; ordered=true)
+    X = (x1=x, x2=z, x3=b, x4=c)
+    @test_throws ArgumentError MLJModelInterface.schema(x)    
+    @test MLJModelInterface.schema(X) == ST.schema(X)
+end
+
 @testset "int, classes, decoder" begin
     N = 10
     mix = shuffle(rng, 0:N - 1)


### PR DESCRIPTION
Depends on https://github.com/JuliaAI/MLJModelInterface.jl/pull/133. Add's the `FullInterface` implementation of the `MLJModelInterface.scitype` method. 
cc. @ablaom 