### PR TITLE
avoid hack for `scitype` import

### DIFF
--- a/src/MLJBase.jl
+++ b/src/MLJBase.jl
@@ -22,8 +22,7 @@ import StatisticalTraits.info
 
 # Interface
 
-# HACK: When https://github.com/JuliaAI/MLJModelInterface.jl/issues/124 and
-# https://github.com/JuliaAI/MLJModelInterface.jl/issues/131 is resolved:
+# HACK: When https://github.com/JuliaAI/MLJModelInterface.jl/issues/124
 # Uncomment next line and delete "Hack Block"
 # using MLJModelInterface
 #####################
@@ -37,8 +36,7 @@ for name in exported_names(MLJModelInterface)
     name in [
         :UnivariateFinite,
         :augmented_transform,
-        :info,
-        :scitype # Needed to avoid clashing with `ScientificTypes.scitype` 
+        :info 
     ] && continue
     quote
         import MLJModelInterface.$name


### PR DESCRIPTION
Avoid hack that was previously required to avoid name clashes with `scitype` method when using both `ScientificTypes.jl` and `MLJModelInterface.jl`. 

The following steps are required, the first four needed before merging this PR and the last after merging.

- [ ]  Merge https://github.com/JuliaAI/MLJModelInterface.jl/pull/135.
- [ ] Yank `MLJModelInterface` (v1.3.4, v1.3.5) and `MLJBase` v0.19.2
- [ ] Tag a new patch release (v 1.6.0) for `MLJModelInterface`.
- [ ] Re-run tests for this PR and Merge if all tests pass.
- [ ] Tag a new minor release (v 1.19.3) for `MLJBase`.
