### PR TITLE
Stacking internal evaluation

### DIFF
--- a/src/composition/models/stacking.jl
+++ b/src/composition/models/stacking.jl
@@ -271,8 +271,8 @@ pre_judge_transform(ŷ::Node, ::Type{<:Deterministic}, ::Type{<:AbstractArray{<
     ŷ
 
 
-maybe_evaluate(mach::Machine, Xtest::AbstractNode, ytest::AbstractNode, measures::Nothing) = nothing
-function maybe_evaluate(mach::Machine, Xtest::AbstractNode, ytest::AbstractNode, measures)
+store_for_evaluation(mach::Machine, Xtest::AbstractNode, ytest::AbstractNode, measures::Nothing) = nothing
+function store_for_evaluation(mach::Machine, Xtest::AbstractNode, ytest::AbstractNode, measures)
     node((ytest, Xtest) -> [mach, Xtest, ytest], ytest, Xtest)
 end
 
@@ -361,7 +361,7 @@ function oos_set(m::Stack, folds::AbstractNode, Xs::Source, ys::Source, verbosit
             mach = machine(model, Xtrain, ytrain)
             ypred = predict(mach, Xtest)
             # Internal evaluation on the fold if required
-            push!(folds_evaluations, maybe_evaluate(mach, Xtest, ytest, m.measures))
+            push!(folds_evaluations, store_for_evaluation(mach, Xtest, ytest, m.measures))
             # Dispatch the computation of the expected mean based on
             # the model type and target_scytype
             ypred = pre_judge_transform(ypred, typeof(model), target_scitype(model))

--- a/src/composition/models/stacking.jl
+++ b/src/composition/models/stacking.jl
@@ -343,7 +343,7 @@ function internal_stack_report(stack::Stack{modelnames,}, verbosity::Int, y, fol
 end
 
 
-function oos_set(m::Stack, folds::AbstractNode, Xs::Source, ys::Source, verbosity::Int)
+function oos_set(m::Stack, folds::AbstractNode, Xs::Source, ys::Source)
     Zval = []
     yval = []
     folds_evaluations = []
@@ -393,7 +393,7 @@ function fit(m::Stack, verbosity::Int, X, y)
     
     folds = getfolds(ys, m.resampling, n)
     
-    Zval, yval, folds_evaluations = oos_set(m, folds, Xs, ys, verbosity)
+    Zval, yval, folds_evaluations = oos_set(m, folds, Xs, ys)
 
     metamach = machine(m.metalearner, Zval, yval)
 

--- a/test/composition/models/stacking.jl
+++ b/test/composition/models/stacking.jl
@@ -329,7 +329,7 @@ end
 @testset "Test maybe_evaluate" begin
     ypred = source([1, 2 , 3, 4])
     ytest = source([1, 2, 3, 5])
-    @test MLJBase.maybe_evaluate(ypred, ytest, nothing) == []
+    @test MLJBase.maybe_evaluate(ypred, ytest, nothing) == nothing
 
     out = MLJBase.maybe_evaluate(ypred, ytest, [rms, rsq])
     @test out() == [0.5, 0.8857142857142857]
@@ -352,7 +352,7 @@ end
                             [source([6, 7]), source([8, 9]), source([10, 11])],
                             [source([12, 13]), source([14, 15]), source([16, 17])])
 
-    internalreport = MLJBase.internal_stack_report(mystack, evaluation_nodes...)()
+    internalreport = MLJBase.internal_stack_report(mystack, evaluation_nodes...).report()
     # FoldId 1
     @test internalreport[1][constant] == [1, 2]
     @test internalreport[1][decisiontree] == [2, 3]

--- a/test/composition/models/stacking.jl
+++ b/test/composition/models/stacking.jl
@@ -351,18 +351,18 @@ end
 end
 
 
-@testset "Test maybe_evaluate" begin
+@testset "Test store_for_evaluation" begin
     X, y = make_blobs(;rng=rng, shuffle=false)
     Xs, ys = source(X), source(y)
     mach = machine(KNNClassifier(), Xs, ys)
     fit!(mach, verbosity=0)
     measures = [accuracy, log_loss]
-    mach_, Xtest, ytest = MLJBase.maybe_evaluate(mach, Xs, ys, measures)()
+    mach_, Xtest, ytest = MLJBase.store_for_evaluation(mach, Xs, ys, measures)()
     @test Xtest == X
     @test ytest == y
     @test mach_ == mach
     # check fallback
-    @test MLJBase.maybe_evaluate(mach, Xs, ys, nothing) === nothing
+    @test MLJBase.store_for_evaluation(mach, Xs, ys, nothing) === nothing
 end
 
 @testset "Test internal_stack_report" begin

--- a/test/composition/models/stacking.jl
+++ b/test/composition/models/stacking.jl
@@ -237,7 +237,7 @@ end
     ys = source(y)
     folds = MLJBase.getfolds(ys, stack.resampling, n)
 
-    Zval, yval, folds_evaluations = MLJBase.oos_set(stack, folds, Xs, ys, 0)
+    Zval, yval, folds_evaluations = MLJBase.oos_set(stack, folds, Xs, ys)
     
     # No internal measure has been provided so the resulting 
     # folds_evaluations contain nothing

--- a/test/composition/models/stacking.jl
+++ b/test/composition/models/stacking.jl
@@ -217,6 +217,22 @@ end
     initial_stack.constant = ConstantClassifier()
     @test_throws DomainError clean!(initial_stack)
 
+    # Test check_stack_measures with 
+    # probabilistic measure and deterministic model
+    measures =[log_loss]
+    stack = Stack(;metalearner=FooBarRegressor(),
+                    resampling=CV(;nfolds=3),
+                    measure=measures,
+                    constant=ConstantRegressor(),
+                    fb=FooBarRegressor())
+    X, y = make_regression()
+
+    @test_throws ArgumentError fit!(machine(stack, X, y), verbosity=0)
+    @test_throws ArgumentError MLJBase.check_stack_measures(stack, 0, measures, y)
+
+    # This will not raise
+    stack.measures = nothing 
+    fit!(machine(stack, X, y), verbosity=0)
 end
 
 @testset  "function oos_set" begin
@@ -425,7 +441,7 @@ end
     ridge = FooBarRegressor()
     mystack = Stack(;metalearner=FooBarRegressor(),
                     resampling=resampling,
-                    measures=measures,
+                    measure=measures,
                     ridge=ridge,
                     constant=constant)
 

--- a/test/composition/models/stacking.jl
+++ b/test/composition/models/stacking.jl
@@ -217,7 +217,12 @@ end
     ys = source(y)
     folds = MLJBase.getfolds(ys, stack.resampling, n)
 
-    Zval, yval = MLJBase.oos_set(stack, folds, Xs, ys)
+    Zval, yval, folds_evaluations = MLJBase.oos_set(stack, folds, Xs, ys)
+    
+    # No internal measure has been provided so the resulting 
+    # folds_evaluations contain nothing
+    @test all(x === nothing for x in folds_evaluations)
+
     # To be accessed, the machines need to be trained
     fit!(Zval, verbosity=0)
     # Each model in the library should output a 3-dim vector to be concatenated
@@ -329,65 +334,88 @@ end
 @testset "Test maybe_evaluate" begin
     ypred = source([1, 2 , 3, 4])
     ytest = source([1, 2, 3, 5])
-    @test MLJBase.maybe_evaluate(ypred, ytest, nothing) == nothing
+    @test MLJBase.maybe_evaluate(ypred, ytest, nothing) === nothing
 
     out = MLJBase.maybe_evaluate(ypred, ytest, [rms, rsq])
     @test out() == [0.5, 0.8857142857142857]
 end
 
 @testset "Test internal_stack_report" begin
-    constant = DeterministicConstantRegressor()
     decisiontree = DecisionTreeRegressor()
     ridge = FooBarRegressor()
     mystack = Stack(;metalearner=FooBarRegressor(),
                     resampling=CV(;nfolds=3),
-                    internal_measures=[rms, rsq],
-                    constant=constant,
+                    internal_measures=[rms, l2],
                     decisiontree=decisiontree,
                     ridge=ridge)
 
+
     # Measures are added incrementally by model for each fold by `maybe_evaluate`
-    # ie: 3 folds, 3 models per fold
-    evaluation_nodes = vcat([source([1, 2]), source([2, 3]), source([4, 5])],
-                            [source([6, 7]), source([8, 9]), source([10, 11])],
-                            [source([12, 13]), source([14, 15]), source([16, 17])])
+    # ie: 3 folds, 2 models per fold and 2 measures per node
+    # The rms measure reports aggregates while l2 reports per observation values
+    evaluation_nodes = vcat([source([1, [1, 2, 3]]), source([2, [4, 5, 6]])],
+                            [source([6, [7, 8, 9]]), source([8, [1, 1, 1]])],
+                            [source([12, [2, 8, 0]]), source([14, [0, 0, 0]])])
 
     internalreport = MLJBase.internal_stack_report(mystack, evaluation_nodes...).report()
-    # FoldId 1
-    @test internalreport[1][constant] == [1, 2]
-    @test internalreport[1][decisiontree] == [2, 3]
-    @test internalreport[1][ridge] == [4, 5]
-    # FoldId 2
-    @test internalreport[2][constant] == [6, 7]
-    @test internalreport[2][decisiontree] == [8, 9]
-    @test internalreport[2][ridge] == [10, 11]
-    # FoldId 1
-    @test internalreport[3][constant] == [12, 13]
-    @test internalreport[3][decisiontree] == [14, 15]
-    @test internalreport[3][ridge] == [16, 17]
+    # decisiontree
+    dtreport = internalreport.decisiontree
+    @test dtreport.measure == [rms, l2]
+    @test dtreport.operation == predict
+
+    @test dtreport.per_observation[1] === missing
+    @test dtreport.per_observation[2] == [[1, 2, 3], [7, 8, 9], [2, 8, 0]]
     
+    @test dtreport.per_fold[1] == [1, 6, 12]
+    @test dtreport.per_fold[2] ≈ [2., 8., 3.333] atol=1e-3
+
+    @test dtreport.measurement[1] == MLJBase.aggregate([1, 6, 12], rms)
+    @test dtreport.measurement[2] ≈ MLJBase.aggregate([2., 8., 3.333], l2) atol=1e-3
+
+    # ridge
+    ridgereport = internalreport.ridge
+    @test ridgereport.measure == [rms, l2]
+    @test ridgereport.operation == predict
+
+    @test ridgereport.per_observation[1] === missing
+    @test ridgereport.per_observation[2] == [[4, 5, 6], [1, 1, 1], [0, 0, 0]]
+    
+    @test ridgereport.per_fold[1] == [2, 8, 14]
+    @test ridgereport.per_fold[2] == [5.0, 1.0, 0.0]
+
+    @test ridgereport.measurement[1] == MLJBase.aggregate([2, 8, 14], rms)
+    @test ridgereport.measurement[2] == MLJBase.aggregate([5.0, 1.0, 0.0], l2) 
+
 end
 
 @testset "Test internal evaluation of the stack" begin
     X, y = make_regression(500, 5; rng=rng)
-    constant = DeterministicConstantRegressor()
     decisiontree = DecisionTreeRegressor()
     ridge = FooBarRegressor()
     mystack = Stack(;metalearner=FooBarRegressor(),
                     resampling=CV(;nfolds=3),
-                    internal_measures=[rms, rsq],
-                    constant=constant,
+                    internal_measures=[rms, l2],
                     decisiontree=decisiontree,
                     ridge=ridge)
+
     mach = machine(mystack, X, y)
     fit!(mach, verbosity=0)
-    perf_measures = report(mach).report
-    @test length(perf_measures) == 3
-    for foldres in perf_measures
-        for (model, perf) in foldres
-            @test any(model == m for m in (constant, decisiontree, ridge))
-         end
+    cvreport = report(mach).cv_report
+    # evaluate decisiontree and ridge out of stack and check results match
+    std_evaluation = (
+        decisiontree = evaluate(decisiontree, X, y, measure=[rms, l2], resampling=CV(nfolds=3)),
+        ridge = evaluate(ridge, X, y, measure=[rms, l2], resampling=CV(nfolds=3))
+        )
+    
+    for modelname in (:ridge, :decisiontree)
+        @test cvreport[modelname].operation == predict
+        @test cvreport[modelname].measure == [rms, l2]
+        @test cvreport[modelname].measurement ≈ std_evaluation[modelname].measurement
+        @test cvreport[modelname].per_fold ≈ std_evaluation[modelname].per_fold 
+        @test cvreport[modelname].per_observation[2] ≈ std_evaluation[modelname].per_observation[2] 
+        @test cvreport[modelname].per_observation[1] === std_evaluation[modelname].per_observation[1] === missing
     end
+
 end
 
 end

--- a/test/composition/models/stacking.jl
+++ b/test/composition/models/stacking.jl
@@ -171,7 +171,7 @@ end
     metalearner = DeterministicConstantRegressor()
     resampling = CV()
 
-    MLJBase.DeterministicStack(modelnames, models, metalearner, resampling)
+    MLJBase.DeterministicStack(modelnames, models, metalearner, resampling, nothing)
 
     # Test input_target_scitypes with non matching target_scitypes
     models = [KNNRegressor()]


### PR DESCRIPTION
I have played around with the stack again. Related to the new functionality [permitting to expose the internal state of a learning network](https://alan-turing-institute.github.io/MLJ.jl/dev/composing_models/#Exposing-internal-state-of-a-learning-network) that you offered in 0.19. The goal would be to optionally report the internal cross validation result of the stack for a given set of measures.

Even though not complete, I think the following provides a poc for this. Before moving forward I wanted to see if you could give me some feedback and guidance on where to go next. A few ideas that come to my mind:

- Formatting of the report, maybe something matching the output of `evaluate!`?
- Maybe I should check that the measures match the stack type?

I hope you can find some time to look into it and happy to take feedback.
