### PR TITLE
Get rid of `ErrorNode`s and fix corner case bug in `replace`

### DIFF
--- a/src/composition/learning_networks/inspection.jl
+++ b/src/composition/learning_networks/inspection.jl
@@ -27,7 +27,6 @@ function tree(W::Node)
     return NamedTuple{keys}(values)
 end
 tree(s::Source) = (source = s,)
-tree(n::ErrorNode) = (node = n,)
 
 # """
 #    args(tree; train=false)

--- a/src/composition/learning_networks/machines.jl
+++ b/src/composition/learning_networks/machines.jl
@@ -394,10 +394,8 @@ function return!(mach::Machine{<:Surrogate},
 
     verbosity isa Nothing || fit!(mach, verbosity=verbosity)
 
-    # anonymize the data, except at source nodes wrapping exceptions:
-    sources = filter(MLJBase.sources(glb(mach))) do s
-        !(s.data isa Exception)
-    end 
+    # anonymize the data
+    sources = MLJBase.sources(glb(mach))
     data = Tuple(s.data for s in sources)
     [MLJBase.rebind!(s, nothing) for s in sources]
 
@@ -418,11 +416,6 @@ network_model_names(model::Nothing, mach::Machine{<:Surrogate}) =
 
 
 ## DUPLICATING AND REPLACING PARTS OF A LEARNING NETWORK MACHINE
-
-function _emptied(s::Source)
-    s.data isa Exception && return source(s.data)
-    return source()
-end
 
 
 """
@@ -475,7 +468,7 @@ function Base.replace(mach::Machine{<:Surrogate},
         "nodes. Contents will be duplicated. "
     end
     if empty_unspecified_sources
-        unspecified_source_pairs = [s => _emptied(s) for
+        unspecified_source_pairs = [s => source() for
                                     s in unspecified_sources]
     else
         unspecified_source_pairs = [s => deepcopy(s) for

--- a/src/composition/learning_networks/machines.jl
+++ b/src/composition/learning_networks/machines.jl
@@ -477,7 +477,6 @@ function Base.replace(mach::Machine{<:Surrogate},
     if empty_unspecified_sources
         unspecified_source_pairs = [s => _emptied(s) for
                                     s in unspecified_sources]
-        @show unspecified_source_pairs
     else
         unspecified_source_pairs = [s => deepcopy(s) for
                                     s in unspecified_sources]

--- a/src/composition/learning_networks/nodes.jl
+++ b/src/composition/learning_networks/nodes.jl
@@ -216,7 +216,6 @@ istoobig(d::Tuple{AbstractNode}) = length(d) > 10
 _formula(stream::IO, X::AbstractNode, indent) =
     (print(stream, repeat(' ', indent));_formula(stream, X, 0, indent))
 _formula(stream::IO, X::Source, depth, indent) = show(stream, X)
-_formula(stream::IO, X::ErrorNode, depth, indent) = show(stream, X)
 function _formula(stream, X::Node, depth, indent)
     operation_name = string(typeof(X.operation).name.mt.name)
     anti = max(length(operation_name) - INDENT)

--- a/src/composition/models/from_network.jl
+++ b/src/composition/models/from_network.jl
@@ -1,6 +1,7 @@
 ## EXPORTING LEARNING NETWORKS AS MODELS WITH @from_network
 
-# closure to generate the fit methods for exported composite. Here `mach`
+# closure to generate the fit methods for exported composite. Here
+# `mach` is a learning network machine.
 function fit_method(mach, models...)
 
     signature = mach.fitresult

--- a/src/composition/models/pipelines.jl
+++ b/src/composition/models/pipelines.jl
@@ -501,7 +501,7 @@ function pipeline_network_machine(super_type,
             node =  first(mach.args)
         end
     else
-        inode = ErrorNode(ERR_INVERSION_NOT_SUPPORTED)
+        inode = source(ERR_INVERSION_NOT_SUPPORTED)
     end
 
     machine(super_type(), source0, sources...;

--- a/src/composition/models/pipelines.jl
+++ b/src/composition/models/pipelines.jl
@@ -469,10 +469,6 @@ extend(front::Front{false}, component, args...) =
 
 # ## The learning network machine
 
-const ERR_INVERSION_NOT_SUPPORTED = ErrorException(
-    "Applying `inverse_transform` to a "*
-    "pipeline that does not support it")
-
 function pipeline_network_machine(super_type,
                                   cache,
                                   operation,
@@ -500,12 +496,12 @@ function pipeline_network_machine(super_type,
             inode = inverse_transform(mach, inode)
             node =  first(mach.args)
         end
-    else
-        inode = source(ERR_INVERSION_NOT_SUPPORTED)
+        return machine(super_type(), source0, sources...;
+                       predict=pnode, transform=tnode, inverse_transform=inode)
     end
 
-    machine(super_type(), source0, sources...;
-            predict=pnode, transform=tnode, inverse_transform=inode)
+    return machine(super_type(), source0, sources...;
+                       predict=pnode, transform=tnode)
 
 end
 

--- a/src/operations.jl
+++ b/src/operations.jl
@@ -76,7 +76,7 @@ for operation in OPERATIONS
     ex = quote
         # 1. operations on machines, given *concrete* data:
         function $operation(mach::Machine, Xraw)
-            if mach.state > 0
+            if mach.state != 0
                 return $(operation)(mach.model,
                                     mach.fitresult,
                                     reformat(mach.model, Xraw)...)

--- a/src/sources.jl
+++ b/src/sources.jl
@@ -36,9 +36,6 @@ The calling behaviour of a `Source` object is this:
     Xs(rows=r) = selectrows(X, r)  # eg, X[r,:] for a DataFrame
     Xs(Xnew) = Xnew
 
-If a `Source` object wraps an object of type `Exception`, then any of
-the above calls will `throw` that object. 
-
 See also: [`@from_network`](@ref], [`sources`](@ref),
 [`origins`](@ref), [`node`](@ref).
 
@@ -58,12 +55,10 @@ color(::Source) = :yellow
 
 # make source nodes callable:
 function (X::Source)(; rows=:)
-    X.data isa Exception && throw(X.data)
     rows == (:) && return X.data
     return selectrows(X.data, rows)
 end
 function (X::Source)(Xnew)
-    X.data isa Exception && throw(X.data)
     return Xnew
 end
 

--- a/test/composition/learning_networks/machines.jl
+++ b/test/composition/learning_networks/machines.jl
@@ -229,6 +229,8 @@ enode = @node mae(ys, yhat)
                          (:train, oakM2), (:train, knnM2)])
 end
 
+
+
 mutable struct DummyComposite <: DeterministicComposite
     stand1
     stand2

--- a/test/composition/models/from_network.jl
+++ b/test/composition/models/from_network.jl
@@ -592,4 +592,30 @@ mach = machine(model, X, y)
 
 end
 
+
+## SOURCE NODES THAT ARE ALSO OPERATION NODES OR ERROR NODES
+
+stand = Standardizer()
+
+Xs = source(rand(3))
+mach1 = machine(stand, Xs)
+X2 = transform(mach1, Xs)
+
+# node for the inverse_transform:
+Z = source(ErrorException("Oh bother!"))
+
+network_mach = machine(Unsupervised(), Xs, transform=X2, inverse_transform=Z)
+
+@from_network network_mach begin
+    struct AppleComposite
+        standardizer = stand
+    end
+end
+
+X = (x = Float64[1, 2, 3],)
+mach = machine(AppleComposite(), X)
+fit!(mach, verbosity=0, force=true)
+@test transform(mach, X).x ≈ Float64[-1, 0, 1]
+@test_throws ErrorException("Oh bother!") inverse_transform(mach, X)
+
 true

--- a/test/composition/models/from_network.jl
+++ b/test/composition/models/from_network.jl
@@ -590,14 +590,12 @@ mach = machine(model, X, y)
            @test_throws(ArgumentError,
                         fit!(mach, verbosity=-1)))
 
-end
-
 
 ## SOURCE NODES THAT ARE ALSO OPERATION NODES OR ERROR NODES
 
 stand = Standardizer()
 
-Xs = source(rand(3))
+Xs = source()
 mach1 = machine(stand, Xs)
 X2 = transform(mach1, Xs)
 
@@ -617,5 +615,7 @@ mach = machine(AppleComposite(), X)
 fit!(mach, verbosity=0, force=true)
 @test transform(mach, X).x ≈ Float64[-1, 0, 1]
 @test_throws ErrorException("Oh bother!") inverse_transform(mach, X)
+
+end
 
 true

--- a/test/composition/models/from_network.jl
+++ b/test/composition/models/from_network.jl
@@ -591,7 +591,7 @@ mach = machine(model, X, y)
                         fit!(mach, verbosity=-1)))
 
 
-## SOURCE NODES THAT ARE ALSO OPERATION NODES OR ERROR NODES
+## SOURCE NODES THAT ARE ALSO OPERATION NODES
 
 stand = Standardizer()
 
@@ -599,10 +599,7 @@ Xs = source()
 mach1 = machine(stand, Xs)
 X2 = transform(mach1, Xs)
 
-# node for the inverse_transform:
-Z = source(ErrorException("Oh bother!"))
-
-network_mach = machine(Unsupervised(), Xs, transform=X2, inverse_transform=Z)
+network_mach = machine(Unsupervised(), Xs, transform=X2, inverse_transform=Xs)
 
 @from_network network_mach begin
     struct AppleComposite
@@ -614,7 +611,7 @@ X = (x = Float64[1, 2, 3],)
 mach = machine(AppleComposite(), X)
 fit!(mach, verbosity=0, force=true)
 @test transform(mach, X).x ≈ Float64[-1, 0, 1]
-@test_throws ErrorException("Oh bother!") inverse_transform(mach, X)
+@test inverse_transform(mach, X) == X 
 
 end
 

--- a/test/composition/models/methods.jl
+++ b/test/composition/models/methods.jl
@@ -486,10 +486,7 @@ end
 
 end
 
-@testset "exporting learning networks with error nodes" begin
-
-    # tests a network with an error node (source node wrapping an
-    # exception) that is also a operation node
+@testset "operation nodes that are source nodes" begin
 
     mutable struct BananaComposite <: UnsupervisedComposite
         stand
@@ -503,9 +500,8 @@ end
         X2 = transform(mach1, Xs)
 
         # node for the inverse_transform:
-        Z = source(ErrorException("Oh bother!"))
 
-        network_mach = machine(Unsupervised(), Xs, transform=X2, inverse_transform=Z)
+        network_mach = machine(Unsupervised(), Xs, transform=X2, inverse_transform=Xs)
         return!(network_mach, model, verbosity)
 
     end
@@ -514,7 +510,7 @@ end
     mach = machine(BananaComposite(), X)
     fit!(mach, verbosity=0, force=true)
     @test transform(mach, X).x ≈ Float64[-1, 0, 1]
-    @test_throws ErrorException("Oh bother!") inverse_transform(mach, X)
+    @test inverse_transform(mach, X) == X
 
 end
 

--- a/test/composition/models/pipelines.jl
+++ b/test/composition/models/pipelines.jl
@@ -367,7 +367,7 @@ end
     end
 
     # test correct error thrown for inverse_transform:
-    @test_throws(MLJBase.ERR_INVERSION_NOT_SUPPORTED,
+    @test_throws(MLJBase.err_unsupported_operation(:inverse_transform),
                  inverse_transform(mach, 3))
 end
 
@@ -413,7 +413,7 @@ end
 
     # Check target_scitype of a supervised pipeline is the same as the supervised component
     @test target_scitype(p) == target_scitype(ConstantClassifier())
-    
+
     # test pipelines with weights:
     w = map(y) do η
         η == 'm' ? 100 : 1
@@ -563,7 +563,7 @@ end
 
 @testset "miscelleneous coverage" begin
     @test MLJBase.as_type(:unsupervised) == Unsupervised
-end 
+end
 
 end
 

--- a/test/sources.jl
+++ b/test/sources.jl
@@ -14,7 +14,7 @@ rebind!(Xs, nothing)
 @test isempty(Xs)
 @test Xs.scitype == Nothing
 
-n = MLJBase.ErrorNode(ArgumentError("Stop!"))
+n = source(ArgumentError("Stop!"))
 @test_throws ArgumentError("Stop!") n(rows=1:3)
 @test_throws ArgumentError("Stop!") n(1:3)
 

--- a/test/sources.jl
+++ b/test/sources.jl
@@ -14,9 +14,5 @@ rebind!(Xs, nothing)
 @test isempty(Xs)
 @test Xs.scitype == Nothing
 
-n = source(ArgumentError("Stop!"))
-@test_throws ArgumentError("Stop!") n(rows=1:3)
-@test_throws ArgumentError("Stop!") n(1:3)
-
 end
 true


### PR DESCRIPTION
In the recent implementation of `Pipeline` we introduced `ErrorNode <: AbstractNode` as a mechanism for throwing errors when an `UnsupervisedPipeline` did not support `inverse_transform`. This is not part of the public API.

This PR:

- Get's rid of `ErrorNodes` by allowing one to instead wrap an `Exception` object in an ordinary `Source` node. Calling the node in that case always *throws* the exception . This is a minor conceptual simplification. It also makes the next fix a little more straightforward. 

-  Fixes a bug in `replace`. This is an internal method used only for composite models exported using `@from_network`. The bug concerns the corner case where an "operation node" is also a `Source` node, and when there were previously `ErrorNode`s. 

**Some details.** The main change to `replace` is to iterate over *all* nodes, not just non-source nodes, when progressively reconstructing the network, and to add logic in the loop that stops the loop looking for ancestors in the special case of a `Source` node.