### PR TITLE
Drop `filename` arg from save(filename, model, ...)

### DIFF
--- a/src/interface/model_api.jl
+++ b/src/interface/model_api.jl
@@ -31,26 +31,35 @@ predict_median(m, fitresult, Xnew, ::Type{<:BadMedianTypes}) =
 MLJModelInterface.implemented_methods(::FI, M::Type{<:MLJType}) =
     getfield.(methodswith(M), :name) |> unique
 
-# the following serialization fallbacks should live in
-# MLJModelInterface when version 2.0 i s released. At that time the
+# The following serialization fallbacks should live in
+# MLJModelInterface when version 2.0 is released. At that time the
 # hack block could also be removed.
+
 #####################
 # hack block begins #
 #####################
 const ERR_SERIALIZATION_FAILURE = ErrorException(
 "Serialization failure. You are using a model that implements an outdated "*
     "version of the serialization API. If you are using "*
-    "a model from XGBoost.jl, be sure to use MLJXGBoostInterface 2.0 or "*
+    "a model from XGBoost.jl, try using MLJXGBoostInterface 2.0 or "*
     "or higher. "
+)
+const ERR_DESERIALIZATION_FAILURE = ErrorException(
+    "Deserialization failure. Your model must be deserialized using "*
+    "using MLJBase < 0.20 and MLJSerialization < 2.0. If this is an "*
+    "XGBoost.jl model, be sure to use MLJXGBoostInterface < 2.0. "
 )
 MLJModelInterface.save(filename, model, fitresult; kwargs...) =
     throw(ERR_SERIALIZATION_FAILURE)
+MLJModelInterface.restore(filename, model, serializable_fitresult) =
+    throw(ERR_DESERIALIZATION_FAILURE)
 ###################
 # hack block ends #
 ###################
+
 MLJModelInterface.save(model, fitresult; kwargs) = fitresult
-MLJModelInterface.restore(filename, model, serializable_fitresult) =
-                          serializable_fitresult
+MLJModelInterface.restore(model, serializable_fitresult) =
+    serializable_fitresult
 
 # to suppress inclusion of abstract types in the model registry.
 for T in (:Supervised, :Unsupervised,

--- a/src/interface/model_api.jl
+++ b/src/interface/model_api.jl
@@ -31,8 +31,24 @@ predict_median(m, fitresult, Xnew, ::Type{<:BadMedianTypes}) =
 MLJModelInterface.implemented_methods(::FI, M::Type{<:MLJType}) =
     getfield.(methodswith(M), :name) |> unique
 
-# serialization fallbacks:
-MLJModelInterface.save(filename, model, fitresult; kwargs...) = fitresult
+# the following serialization fallbacks should live in
+# MLJModelInterface when version 2.0 i s released. At that time the
+# hack block could also be removed.
+#####################
+# hack block begins #
+#####################
+const ERR_SERIALIZATION_FAILURE = ErrorException(
+"Serialization failure. You are using a model that implements an outdated "*
+    "version of the serialization API. If you are using "*
+    "a model from XGBoost.jl, be sure to use MLJXGBoostInterface 2.0 or "*
+    "or higher. "
+)
+MLJModelInterface.save(filename, model, fitresult; kwargs...) =
+    throw(ERR_SERIALIZATION_FAILURE)
+###################
+# hack block ends #
+###################
+MLJModelInterface.save(model, fitresult; kwargs) = fitresult
 MLJModelInterface.restore(filename, model, serializable_fitresult) =
                           serializable_fitresult
 


### PR DESCRIPTION
In support of https://github.com/JuliaAI/MLJSerialization.jl/pull/17 .

Note PR is onto `for-a-0-point-20-release` branch, not onto `dev`.

cc @olivierlabayle 