### PR TITLE
Refactor model scitype check2

### DIFF
--- a/src/machines.jl
+++ b/src/machines.jl
@@ -93,9 +93,17 @@ warn_scitype(model::Supervised, X) =
     "input_scitype(model) = $(input_scitype(model))."
 
 warn_generic_scitype_mismatch(S, F) =
-    "The scitype of `args` in `machine(model, args...; kwargs)` "*
-    "does not match the scitype "*
-    "expected by model's `fit` method.\n"*
+    "The number and/or types of data arguments do not " *
+    "match what the specified model supports. Commonly, " *
+    "but non exclusively, supervised models are constructed " *
+    "using the syntax `machine(model, X, y)` or `machine(model, X, y, w)` " *
+    "while most other models with `machine(model, X)`. " *
+    "Here `X` are features, `y` a target, and `w` sample or class weights. " *
+    "In general, data in `machine(model, data...)` must satisfy " *
+    "`scitype(data) <: MLJ.fit_data_scitype(model)` unless the " *
+    "right-hand side is `Unknown`.  Here, the scitype of `args` " *
+    "in `machine(model, args...; kwargs)` does not match the scitype " *
+    "expected by model's `fit` method.\n" *
     "  provided: $S\n  expected by fit: $F"
 
 warn_scitype(model::Supervised, X, y) =
@@ -117,56 +125,6 @@ err_length_mismatch(model::Supervised) = DimensionMismatch(
 check(model::Any, args...; kwargs...) =
     throw(ArgumentError("Expected a `Model` instance, got $model. "))
 
-function check_supervised(model, full, args...)
-    nowarns = true
-
-    nargs = length(args)
-    nargs > 1 || throw(err_supervised_nargs())
-
-    full || return nowarns
-
-    X, y = args[1:2]
-
-    # checks on input type:
-    input_scitype(model) <: Unknown ||
-        elscitype(X) <: input_scitype(model) || begin
-            @warn warn_scitype(model, X)
-            nowarns=false
-        end
-
-    # checks on target type:
-    target_scitype(model) <: Unknown ||
-        elscitype(y) <: target_scitype(model) || begin
-            @warn warn_scitype(model, X, y)
-            nowarns=false
-        end
-
-    # checks on dimension matching:
-    scitype(X) == CallableReturning{Nothing} || nrows(X()) == nrows(y()) ||
-        throw(err_length_mismatch(model))
-
-    return nowarns
-
-end
-
-function check_unsupervised(model, full, args...)
-    nowarns = true
-
-    nargs = length(args)
-    nargs <= 1 || throw(err_unsupervised_nargs())
-
-    if full && nargs == 1
-        X = args[1]
-        # check input scitype
-        input_scitype(model) <: Unknown ||
-            elscitype(X) <: input_scitype(model) || begin
-                @warn warn_scitype(model, X)
-                nowarns=false
-            end
-    end
-    return nowarns
-end
-
 function check(model::Model, args...; full=false)
     nowarns = true
 
@@ -174,26 +132,18 @@ function check(model::Model, args...; full=false)
     (F >: Unknown || F >: Tuple{Unknown} || F >: NTuple{<:Any,Unknown}) &&
         return true
 
-    S = Tuple{elscitype.(args)...}
+    S = Tuple{scitype.(args)...}
     if !(S <: F)
         @warn warn_generic_scitype_mismatch(S, F)
         nowarns = false
     end
-end
 
-function check(model::Union{Supervised, SupervisedAnnotator}, args... ; full = false)
-    check_supervised(model, full, args...)
-end
+    if length(args) > 1
+        X, y = args[1:2]
 
-function check(model::Unsupervised, args...; full=false)
-    check_unsupervised(model, full, args...)
-end
-
-function check(model::UnsupervisedAnnotator, args... ; full = false)
-    if length(args) <= 1
-        check_unsupervised(model, full, args...)
-    else
-        check_supervised(model, full, args...)
+        # checks on dimension matching:
+        scitype(X) == CallableReturning{Nothing} || nrows(X()) == nrows(y()) ||
+            throw(err_length_mismatch(model))
     end
 end
 

--- a/src/machines.jl
+++ b/src/machines.jl
@@ -87,16 +87,17 @@ function _contains_unknown(F::Type{<:Tuple})
     return any(_contains_unknown, F.parameters)
 end
 
-warn_generic_scitype_mismatch(S, F) =
+warn_generic_scitype_mismatch(S, F, T) =
     "The number and/or types of data arguments do not " *
     "match what the specified model supports.\n"*
+    "Run `@doc $T` to learn more about your model's requirements.\n\n"*
     "Commonly, but non exclusively, supervised models are constructed " *
     "using the syntax `machine(model, X, y)` or `machine(model, X, y, w)` " *
     "while most other models with `machine(model, X)`. " *
     "Here `X` are features, `y` a target, and `w` sample or class weights.\n" *
     "In general, data in `machine(model, data...)` must satisfy " *
     "`scitype(data) <: MLJ.fit_data_scitype(model)` unless the " *
-    "right-hand side is `Unknown`.\n"*
+    "right-hand side contains `Unknown` scitypes.\n"*
     "In the present case:\n"*
     "scitype(data) = $S\n"*
     "fit_data_scitype(model) = $F\n"
@@ -120,7 +121,7 @@ function check(model::Model, args...; full=false)
     # wrapped in source nodes:
     S = Tuple{elscitype.(args)...}
     if !(S <: F)
-        @warn warn_generic_scitype_mismatch(S, F)
+        @warn warn_generic_scitype_mismatch(S, F, typeof(model))
         nowarns = false
     end
 

--- a/src/machines.jl
+++ b/src/machines.jl
@@ -132,7 +132,7 @@ function check(model::Model, args...; full=false)
     (F >: Unknown || F >: Tuple{Unknown} || F >: NTuple{<:Any,Unknown}) &&
         return true
 
-    S = Tuple{scitype.(args)...}
+    S = Tuple{elscitype.(args)...}
     if !(S <: F)
         @warn warn_generic_scitype_mismatch(S, F)
         nowarns = false

--- a/test/_models/MultivariateStats.jl
+++ b/test/_models/MultivariateStats.jl
@@ -97,13 +97,13 @@ function MLJBase.fit(model::PCA, verbosity::Int, X)
                        mean=model.mean)
 
     cache = nothing
-    report = (indim=MS.indim(fitresult),
-              outdim=MS.outdim(fitresult),
+    report = (indim=size(fitresult)[1],
+              outdim=size(fitresult)[2],
               mean=MS.mean(fitresult),
               principalvars=MS.principalvars(fitresult),
               tprincipalvar=MS.tprincipalvar(fitresult),
               tresidualvar=MS.tresidualvar(fitresult),
-              tvar=MS.tvar(fitresult))
+              tvar=MS.var(fitresult))
 
     return fitresult, cache, report
 end
@@ -114,7 +114,7 @@ MLJBase.fitted_params(::PCA, fr) = (projection=fr,)
 function MLJBase.transform(::PCA, fr::PCAFitResultType, X)
     # X is n x d, need to transpose and copy twice...
     Xarray = MLJBase.matrix(X)
-    Xnew   = permutedims(MS.transform(fr, permutedims(Xarray)))
+    Xnew   = permutedims(MS.predict(fr, permutedims(Xarray)))
     return MLJBase.table(Xnew, prototype=X)
 end
 

--- a/test/composition/learning_networks/nodes.jl
+++ b/test/composition/learning_networks/nodes.jl
@@ -28,7 +28,8 @@ y = 2X.x1  - X.x2 + 0.05*rand(N);
                (:info, r"Running type checks"),
                (:warn, MLJBase.warn_generic_scitype_mismatch(
                    scitype((X, y)),
-                   MLJBase.fit_data_scitype(mach2.model)
+                   MLJBase.fit_data_scitype(mach2.model),
+                   typeof(mach2.model)
                )),
                (:info, r"^It seems an upstream"),
                (:error, r"^Problem fitting"),
@@ -41,7 +42,8 @@ y = 2X.x1  - X.x2 + 0.05*rand(N);
                (:info, r"Running type checks"),
                (:warn, MLJBase.warn_generic_scitype_mismatch(
                    Tuple{Nothing},
-                   MLJBase.fit_data_scitype(mach1.model)
+                   MLJBase.fit_data_scitype(mach1.model),
+                   typeof(mach1.model)
                )),
                (:info, r"^It seems an upstream"),
                (:error, r"^Problem fitting"),

--- a/test/composition/learning_networks/nodes.jl
+++ b/test/composition/learning_networks/nodes.jl
@@ -9,9 +9,6 @@ using CategoricalArrays
 import Random.seed!
 seed!(1234)
 
-KNNRegressor()
-DecisionTreeClassifier()
-
 N =100
 X = (x1=rand(N), x2=rand(N), x3=rand(N));
 y = 2X.x1  - X.x2 + 0.05*rand(N);
@@ -29,18 +26,23 @@ y = 2X.x1  - X.x2 + 0.05*rand(N);
     yhat = predict(mach2, W)
     @test_logs((:error, r"Problem fitting"),
                (:info, r"Running type checks"),
-               (:warn, r"^The scitype of"),
+               (:warn, MLJBase.warn_generic_scitype_mismatch(
+                   scitype((X, y)),
+                   MLJBase.fit_data_scitype(mach2.model)
+               )),
                (:info, r"^It seems an upstream"),
                (:error, r"^Problem fitting"),
                @test_throws Exception fit!(yhat, verbosity=-1))
-
     Xs = source()
     mach1 = machine(Standardizer(), Xs)
     W = transform(mach1, Xs)
     @test_logs((:error, r"Problem fitting"),
                (:warn, r"^Some learning network source"),
                (:info, r"Running type checks"),
-               (:warn, r"^The scitype of"),
+               (:warn, MLJBase.warn_generic_scitype_mismatch(
+                   Tuple{Nothing},
+                   MLJBase.fit_data_scitype(mach1.model)
+               )),
                (:info, r"^It seems an upstream"),
                (:error, r"^Problem fitting"),
                @test_throws Exception fit!(W, verbosity=-1))

--- a/test/composition/models/deprecated.jl
+++ b/test/composition/models/deprecated.jl
@@ -478,9 +478,10 @@ pdf(predict(mach, X)[1], 'f') ≈ 4/7
 # test invalid replacement of classifier with regressor throws
 # informative error message:
 p.constant_classifier = ConstantRegressor()
+
 @test_logs((:error, r"^Problem"),
            (:info, r"^Running type"),
-           (:warn, r"The scitype of"),
+           (:warn, r""),
            (:info, r"It seems"),
            (:error, r"Problem"),
            @test_throws Exception fit!(mach, verbosity=-1))

--- a/test/composition/models/pipelines.jl
+++ b/test/composition/models/pipelines.jl
@@ -395,7 +395,8 @@ end
            (:info, r"^Running type"),
                (:warn, MLJBase.warn_generic_scitype_mismatch(
                    scitype((X, y)),
-                   MLJBase.fit_data_scitype(ConstantRegressor())
+                   MLJBase.fit_data_scitype(ConstantRegressor()),
+                   typeof(ConstantRegressor())
                )),
            (:info, r"It seems"),
            (:error, r"Problem"),

--- a/test/composition/models/pipelines.jl
+++ b/test/composition/models/pipelines.jl
@@ -393,7 +393,10 @@ end
     p.constant_classifier = ConstantRegressor()
     @test_logs((:error, r"^Problem"),
            (:info, r"^Running type"),
-           (:warn, r"The scitype of"),
+               (:warn, MLJBase.warn_generic_scitype_mismatch(
+                   scitype((X, y)),
+                   MLJBase.fit_data_scitype(ConstantRegressor())
+               )),
            (:info, r"It seems"),
            (:error, r"Problem"),
                @test_throws Exception fit!(mach, verbosity=-1))

--- a/test/composition/models/stacking.jl
+++ b/test/composition/models/stacking.jl
@@ -32,7 +32,7 @@ function test_internal_evaluation(internalreport, std_evaluation, modelnames)
         @test model_ev.per_fold == std_ev.per_fold
         @test model_ev.measurement == std_ev.measurement
         @test model_ev.per_observation[1] === std_ev.per_observation[1] === missing
-        @test model_ev.per_observation[2] == std_ev.per_observation[2] 
+        @test model_ev.per_observation[2] == std_ev.per_observation[2]
         @test model_ev.operation == std_ev.operation
         @test model_ev.report_per_fold == std_ev.report_per_fold
         @test model_ev.train_test_rows == std_ev.train_test_rows
@@ -47,38 +47,38 @@ end
     # Testing performance
 
     # The dataset is a simple regression model with intercept
-    # No model in the stack can recover the true model on its own 
-    # Indeed, FooBarRegressor has no intercept 
+    # No model in the stack can recover the true model on its own
+    # Indeed, FooBarRegressor has no intercept
     # By combining models, the stack can generalize better than any submodel
     # And optimize the rmse
 
     models = (constant=DeterministicConstantRegressor(),
-                decisiontree=DecisionTreeRegressor(), 
-                ridge_lambda=FooBarRegressor(;lambda=0.1), 
+                decisiontree=DecisionTreeRegressor(),
+                ridge_lambda=FooBarRegressor(;lambda=0.1),
                 ridge=FooBarRegressor(;lambda=0))
 
     mystack = Stack(;metalearner=FooBarRegressor(),
                     resampling=CV(;nfolds=3),
                     models...)
-    
+
     results = model_evaluation((stack=mystack, models...), X, y)
     @test argmin(results) == 1
 
     # Mixing ProbabilisticModels amd Deterministic models as members of the stack
     models = (constant=ConstantRegressor(),
-                decisiontree=DecisionTreeRegressor(), 
-                ridge_lambda=FooBarRegressor(;lambda=0.1), 
+                decisiontree=DecisionTreeRegressor(),
+                ridge_lambda=FooBarRegressor(;lambda=0.1),
                 ridge=FooBarRegressor(;lambda=0))
 
     mystack = Stack(;metalearner=FooBarRegressor(),
                     resampling=CV(;nfolds=3),
                     models...)
     # Testing attribute access of the stack
-    @test propertynames(mystack) == (:resampling, :metalearner, :constant, 
+    @test propertynames(mystack) == (:resampling, :metalearner, :constant,
                                     :decisiontree, :ridge_lambda, :ridge)
 
     @test mystack.decisiontree isa DecisionTreeRegressor
-    
+
     @test target_scitype(mystack) == target_scitype(FooBarRegressor())
     @test input_scitype(mystack) == input_scitype(FooBarRegressor())
 
@@ -93,7 +93,7 @@ end
     @test nrows(getfield(fp, :ridge)) == 4
     @test nrows(getfield(fp, :ridge_lambda)) == 4
 
-    # The metalearner has been fit and has one coefficient 
+    # The metalearner has been fit and has one coefficient
     # for each model in the library (No intercept)
     @test fp.metalearner isa Vector{Float64}
     @test nrows(fp.metalearner) == 4
@@ -104,8 +104,8 @@ end
 
     @testset "Testing ProbabilisticStack" begin
         models = (constant=ConstantRegressor(),
-                    decisiontree=DecisionTreeRegressor(), 
-                    ridge_lambda=FooBarRegressor(;lambda=0.1), 
+                    decisiontree=DecisionTreeRegressor(),
+                    ridge_lambda=FooBarRegressor(;lambda=0.1),
                     ridge=FooBarRegressor(;lambda=0))
 
         # The type of the stack is determined by the type of the metalearner
@@ -129,14 +129,14 @@ end
     X, y = make_blobs(;rng=rng, shuffle=false)
 
     models = (constant=ConstantClassifier(),
-                decisiontree=DecisionTreeClassifier(), 
+                decisiontree=DecisionTreeClassifier(),
                 knn=KNNClassifier())
 
     mystack = Stack(;metalearner=DecisionTreeClassifier(),
                     resampling=StratifiedCV(;nfolds=3),
                     models...)
-    
-    
+
+
     # Check input and target scitypes
     @test target_scitype(mystack) == target_scitype(DecisionTreeClassifier())
     # Here the greatest lower bound is the scitype of the knn
@@ -158,10 +158,10 @@ end
 end
 
 
-@testset "Misc" begin 
+@testset "Misc" begin
     # Test setproperty! behaviour
     models = (constant=DeterministicConstantRegressor(),
-                decisiontree=DecisionTreeRegressor(), 
+                decisiontree=DecisionTreeRegressor(),
                 ridge_lambda=FooBarRegressor(;lambda=0.1))
 
     mystack = Stack(;metalearner=FooBarRegressor(),
@@ -171,7 +171,7 @@ end
     @test mystack.ridge_lambda.lambda == 0.1
     @test mystack.metalearner isa FooBarRegressor
     @test mystack.resampling isa CV
-    
+
     mystack.ridge_lambda = FooBarRegressor(;lambda=0.2)
     @test mystack.ridge_lambda.lambda == 0.2
 
@@ -205,7 +205,7 @@ end
     metalearner = KNNClassifier()
     inp_scitype, tg_scitype = MLJBase.input_target_scitypes(models, metalearner)
     @test tg_scitype == AbstractVector{<:Finite}
-    @test inp_scitype == Table{<:Union{AbstractVector{<:Continuous}, 
+    @test inp_scitype == Table{<:Union{AbstractVector{<:Continuous},
                                        AbstractVector{<:Count},
                                        AbstractVector{<:OrderedFactor}}}
 
@@ -217,7 +217,7 @@ end
     initial_stack.constant = ConstantClassifier()
     @test_throws DomainError clean!(initial_stack)
 
-    # Test check_stack_measures with 
+    # Test check_stack_measures with
     # probabilistic measure and deterministic model
     measures =[log_loss]
     stack = Stack(;metalearner=FooBarRegressor(),
@@ -227,11 +227,15 @@ end
                     fb=FooBarRegressor())
     X, y = make_regression()
 
-    @test_throws ArgumentError fit!(machine(stack, X, y), verbosity=0)
+    @test_logs((:error, r"Problem fitting"),
+               (:info, r"Running type"),
+               (:info, r"Type checks okay"),
+               @test_throws ArgumentError fit!(machine(stack, X, y), verbosity=0))
+
     @test_throws ArgumentError MLJBase.check_stack_measures(stack, 0, measures, y)
 
     # This will not raise
-    stack.measures = nothing 
+    stack.measures = nothing
     fit!(machine(stack, X, y), verbosity=0)
 end
 
@@ -254,15 +258,15 @@ end
     folds = MLJBase.getfolds(ys, stack.resampling, n)
 
     Zval, yval, folds_evaluations = MLJBase.oos_set(stack, folds, Xs, ys)
-    
-    # No internal measure has been provided so the resulting 
+
+    # No internal measure has been provided so the resulting
     # folds_evaluations contain nothing
     @test all(x === nothing for x in folds_evaluations)
 
     # To be accessed, the machines need to be trained
     fit!(Zval, verbosity=0)
     # Each model in the library should output a 3-dim vector to be concatenated
-    # resulting in the table of shape (nrows, 6) here nrows=6 
+    # resulting in the table of shape (nrows, 6) here nrows=6
     # for future use by the metalearner
     sc = schema(Zval())
     @test nrows(Zval()) == 6
@@ -287,7 +291,7 @@ end
     # This is a distribution, we need to apply the appropriate transformation
     Zval_expected = pdf(Zval_expected_dist, levels(first(Zval_expected_dist)))
     @test matrix(Zval())[1:2, 1:3] == Zval_expected
-    
+
 end
 
 @testset "An integration test for stacked classification" begin
@@ -295,7 +299,7 @@ end
     # We train a stack by hand and compare with the canned version
     # `Stack(...)`. There are two base learners, with 3-fold
     # cross-validation used to construct the out-of-sample base model
-    # predictions. 
+    # predictions.
 
     probs(y) = pdf(y, levels(first(y)))
 
@@ -363,7 +367,7 @@ end
 
     # compare:
     @test yhat_matrix_stack ≈ yhat_matrix
-    
+
 end
 
 
@@ -413,15 +417,15 @@ end
             mach = machine(model, X, y)
             fit!(mach, verbosity=0, rows=train)
             Xtest = selectrows(X, test)
-            ytest = selectrows(y, test)    
+            ytest = selectrows(y, test)
             push!(evaluation_nodes, source((mach, Xtest, ytest)))
         end
     end
 
     internalreport = MLJBase.internal_stack_report(
-        mystack, 
-        0, 
-        ys, 
+        mystack,
+        0,
+        ys,
         evaluation_nodes...
     ).report.cv_report()
 
@@ -453,7 +457,7 @@ end
         constant = evaluate(constant, X, y, measure=measures, resampling=resampling, verbosity=0),
         ridge = evaluate(ridge, X, y, measure=measures, resampling=resampling, verbosity=0)
         )
-    
+
     test_internal_evaluation(internalreport, std_evaluation, (:constant, :ridge))
     @test std_evaluation.constant.fitted_params_per_fold == internalreport.constant.fitted_params_per_fold
     @test std_evaluation.ridge.fitted_params_per_fold == internalreport.ridge.fitted_params_per_fold
@@ -480,7 +484,7 @@ end
         constant = evaluate(constant, X, y, measure=measures, resampling=resampling, verbosity=0),
         knn = evaluate(knn, X, y, measure=measures, resampling=resampling, verbosity=0)
         )
-    
+
     test_internal_evaluation(internalreport, std_evaluation, (:knn, :constant))
     # Test fitted_params
     for i in 1:mystack.resampling.nfolds

--- a/test/machines.jl
+++ b/test/machines.jl
@@ -72,7 +72,8 @@ freeze!(stand)
     @test_logs((:warn,
                 MLJBase.warn_generic_scitype_mismatch(
                     Tuple{scitype(X), AbstractVector{Multiclass{N}}},
-                    MLJBase.fit_data_scitype(tree)
+                    MLJBase.fit_data_scitype(tree),
+                    typeof(tree)
                     )
                 ),
                machine(tree, X, categorical(1:N)))
@@ -81,7 +82,8 @@ freeze!(stand)
     @test_logs((:warn,
                 MLJBase.warn_generic_scitype_mismatch(
                     Tuple{scitype(42),},
-                    MLJBase.fit_data_scitype(pca)
+                    MLJBase.fit_data_scitype(pca),
+                    typeof(pca)
                     )
                 ),
                machine(pca, 42))
@@ -91,7 +93,8 @@ freeze!(stand)
     @test_logs((:warn,
                 MLJBase.warn_generic_scitype_mismatch(
                     Tuple{scitype(X), scitype(y2), scitype(42)},
-                    MLJBase.fit_data_scitype(ConstantClassifier())
+                    MLJBase.fit_data_scitype(ConstantClassifier()),
+                    ConstantClassifier
                     )
                 ),
                machine(ConstantClassifier(), X, y2, 42))
@@ -111,7 +114,8 @@ MLJBase.fit_data_scitype(::Type{<:FooBar}) =
     @test_logs machine(model, X)
     @test_logs((:warn,
                 MLJBase.warn_generic_scitype_mismatch(Tuple{scitype(y)},
-                                                      fit_data_scitype(model))),
+                                                      fit_data_scitype(model),
+                                                      FooBar)),
                 machine(model, y))
 end
 


### PR DESCRIPTION
Continuation of #731.
Needs: 

- [x] https://github.com/JuliaRegistries/General/pull/53351 merged


@pazzo83 Be good if you review this (the most recent commits). The main problems fixed in this continuation are:

- A [bug](https://github.com/JuliaAI/MLJModelInterface.jl/pull/137) in MLJModelInterface for constructing the fallback for `fit_data_scitype` for supervised models supporting weights (so not part of this PR, but partly responsible for failure of tests in #731)
- Flawed logic for testing presence of `Unknown` in `fit_data_scitype`. This is now a separate function `_contains_unknown` with tests.
- `check_model_scitype` was not returning the value of `nowarns`
- a lot of logging checks needed updating

The difficulties encountered in #731 are due in some part to a lack of testing of the `check_model_scitype` "fallback" we are now using as the main method. The methods we are removing were covering up this lack of testing, but that's a poor excuse. My apologies for this. 

To do:
- [x] Remove redundant code (mostly a bunch of warning strings that no longer apply)
- [x] Rebase this PR onto `for-a-0-point-20-release`. Technically, the only "breaking" change is changes to strings in the warnings. However, I think these changes are pretty critical for new users, for which the new warnings will be more cryptic. So, we may want to at least wait for some progress on https://github.com/alan-turing-institute/MLJ.jl/issues/898 before releasing the changes here. @pazzo83 You could continue development of "supervised" transformers using the `for-a-0-point-20-release` branch? This is being regularly rebased onto dev. What do you think?

