### PR TITLE
make the stack's resampling scheme more general

### DIFF
--- a/src/composition/models/stacking.jl
+++ b/src/composition/models/stacking.jl
@@ -249,11 +249,8 @@ MLJBase.package_license(::Type{<:Stack}) = "MIT"
 ###########################################################
 
 
-getfolds(y::AbstractNode, cv::CV, n::Int) =
-    source(train_test_pairs(cv, 1:n))
-
-getfolds(y::AbstractNode, cv::StratifiedCV, n::Int) =
-    node(YY->train_test_pairs(cv, 1:n, YY), y)
+getfolds(X::AbstractNode, y::AbstractNode, cv, n::Int) =
+    node((XX, YY) -> train_test_pairs(cv, 1:n, XX, YY), X, y)
 
 trainrows(X::AbstractNode, folds::AbstractNode, nfold) =
     node((XX, ff) -> selectrows(XX, ff[nfold][1]), X, folds)
@@ -435,7 +432,7 @@ function fit(m::Stack, verbosity::Int, X, y)
     Xs = source(X)
     ys = source(y)
     
-    folds = getfolds(ys, m.resampling, n)
+    folds = getfolds(Xs, ys, m.resampling, n)
     
     Zval, yval, folds_evaluations = oos_set(m, folds, Xs, ys)
 

--- a/src/composition/models/stacking.jl
+++ b/src/composition/models/stacking.jl
@@ -248,9 +248,6 @@ MLJBase.package_license(::Type{<:Stack}) = "MIT"
 ################# Node operations Methods #################
 ###########################################################
 
-selectrows(X::AbstractNode, idx) = 
-    node(X-> selectrows(X, idx), X)
-
 pre_judge_transform(ŷ::Node, ::Type{<:Probabilistic}, ::Type{<:AbstractArray{<:Finite}}) =
     node(ŷ -> pdf(ŷ, levels(first(ŷ))), ŷ)
 

--- a/test/composition/models/stacking.jl
+++ b/test/composition/models/stacking.jl
@@ -247,11 +247,11 @@ end
     stack = Stack(metalearner=judge,
                 model1=model1,
                 model2=model2,
-                resampling=CV(;nfolds=3, shuffle=true, rng=rng))
+                resampling=CV(;nfolds=3, shuffle=false))
 
     Xs = source(X)
     ys = source(y)
-    folds = MLJBase.getfolds(ys, stack.resampling, n)
+    folds = MLJBase.getfolds(Xs, ys, stack.resampling, n)
 
     Zval, yval, folds_evaluations = MLJBase.oos_set(stack, folds, Xs, ys)
     


### PR DESCRIPTION
Unless I am missing something I think the existing version of `getfolds` is restrictive. 
This is a simple extension of the capabilities of resampling schemes. 

@edit 
I am converting to draft as I am also trying to get rid of the assumption that the resampling method needs a `nfolds` field and rely only on `train_test_pairs`.