### PR TITLE
When constructing a `TransformedTargetModel`, allow the user to override the `target_scitype`, `predict_scitype`, and `prediction_type` traits

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -50,7 +50,10 @@ julia = "1.6"
 [extras]
 DecisionTree = "7806a523-6efd-50cb-b5f6-3fa6f1930dbb"
 Distances = "b4f34e82-e78d-54a5-968a-f98e89d6e8f7"
+EvoTrees = "f6006082-12f8-11e9-0c9c-0d5d367ab1e5"
 Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
+MLJ = "add582a8-e3ab-11e8-2d5e-e98b27df1bc7"
+MLJModels = "d491faf4-2d78-11e9-2867-c94bc002c0b7"
 MultivariateStats = "6f286f6a-111f-5878-ab1e-185364afe411"
 NearestNeighbors = "b8a86587-4115-5ab1-83bc-aa920d37bbce"
 StableRNGs = "860ef19b-820b-49d6-a774-d7a799459cd3"
@@ -58,4 +61,4 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 TypedTables = "9d95f2ec-7b3d-5a63-8d20-e2491e220bb9"
 
 [targets]
-test = ["DecisionTree", "Distances", "Logging", "MultivariateStats", "NearestNeighbors", "StableRNGs", "Test", "TypedTables"]
+test = ["DecisionTree", "Distances", "EvoTrees", "Logging", "MLJ", "MLJModels", "MultivariateStats", "NearestNeighbors", "StableRNGs", "Test", "TypedTables"]

--- a/test/composition/models/evotrees.jl
+++ b/test/composition/models/evotrees.jl
@@ -1,0 +1,136 @@
+import CategoricalArrays
+import EvoTrees
+import MLJ
+import ScientificTypes
+
+const EvoTreeRegressor = MLJ.@load EvoTreeRegressor pkg=EvoTrees
+
+function get_classes(; levels, pool)
+    num_levels  = length(levels)
+    pool_length = length(pool)
+    if num_levels != pool_length
+        msg = "`num_levels` is `$(num_levels)` but `pool_length` is `$(pool_length)`"
+        throw(ArgumentError(msg))
+    end
+    if num_levels > 2
+        string(
+            "There are $(num_levels) levels, but the ",
+            "`RegressorToBinaryClassifier` wrapper only supports binary ",
+            "classification",
+        )
+        throw(ErrorException(msg))
+    end
+    if num_levels < 2
+        string(
+            "Target `y` must have two classes in its pool, even if only one ",
+            "class is manifest",
+        )
+        throw(ErrorException(msg))
+    end
+    negative_class = levels[1]
+    positive_class = levels[2]
+    return (; negative_class, positive_class)
+end
+
+function get_levels_and_pool(y)
+    levels = MLJ.levels(y)
+    pool = CategoricalArrays.pool(y)
+    classes = get_classes(; levels, pool)
+    negative_class = classes.negative_class
+    positive_class = classes.positive_class
+    scitype = MLJ.scitype(y)
+    if scitype <: AbstractVector{MLJ.OrderedFactor{2}}
+    elseif scitype <: AbstractVector{<:MLJ.Multiclass{2}}
+        warning = string(
+            "Taking positive class as $(positive_class)",
+            " and negative class as $(negative_class)",
+            ". Coerce target to `OrderedFactor{2}` to suppress this warning, ",
+            "ensuring that positive class > negative class",
+        )
+        @warn warning
+    else
+        msg = "Unsupported scitype: $(scitype)"
+        throw(ArgumentError(msg))
+    end
+    return (; levels, pool)
+end
+
+function transform(::Type{T}, y_categorical::AbstractVector; levels, pool) where {T}
+    classes = get_classes(; levels, pool)
+    negative_class = classes.negative_class
+    positive_class = classes.positive_class
+    n = length(y_categorical)
+    y_numerical = Vector{T}(undef, n)
+    for i in 1:n
+        cat = y_categorical[i]
+        if cat == positive_class
+            num = T(1)
+        elseif cat == negative_class
+            num = T(0)
+        else
+            msg = "Invalid value: $(cat)"
+            throw(ErrorException(msg))
+        end
+        y_numerical[i] = num
+    end
+    return y_numerical
+end
+
+function inverse_transform(y_single_probability::AbstractVector; levels, pool)
+    classes = get_classes(; levels, pool)
+    negative_class = classes.negative_class
+    positive_class = classes.positive_class
+    n = length(y_single_probability)
+    y_probability_distribution = Vector{MLJ.UnivariateFinite}(undef, n)
+    for i in 1:n
+        single_prob = y_single_probability[i]
+        prob_dist = MLJ.UnivariateFinite(
+            levels,
+            single_prob;
+            pool,
+            augment = true,
+        )
+        y_probability_distribution[i] = prob_dist
+    end
+    return y_probability_distribution
+end
+
+X, y = MLJ.@load_crabs
+
+levels_and_pool = get_levels_and_pool(y)
+levels = levels_and_pool.levels
+pool = levels_and_pool.pool
+
+device = "cpu"
+# device = "gpu"
+loss = :logistic
+metric = :none
+atom = EvoTreeRegressor(; device, loss, metric)
+
+traits = Dict{Symbol, Any}()
+traits[:target_scitype]  = AbstractVector{<:MLJ.Finite}
+traits[:predict_scitype] = AbstractVector{<:ScientificTypes.Density{<:MLJ.Finite}}
+traits[:prediction_type] = :probabilistic
+
+model = MLJ.TransformedTargetModel(
+    atom;
+    traits,
+    target  = y -> transform(Float64, y; levels, pool),
+    inverse = y -> inverse_transform( y; levels, pool),
+)
+
+nfolds = 5
+resampling = MLJ.CV(; nfolds, shuffle = true)
+measure = MLJ.auc # AUC = AUROC = area under the ROC curve
+mach = MLJ.machine(
+    model,
+    X,
+    y,
+)
+performance_evaluation = MLJ.evaluate!(
+    mach;
+    resampling,
+    measure,
+)
+display(performance_evaluation)
+@test only(performance_evaluation.measurement) > 0.85

--- a/test/composition/models/transformed_target_model.jl
+++ b/test/composition/models/transformed_target_model.jl
@@ -159,6 +159,10 @@ y = rand(5)
     @test training_losses(mach) == ones(5)
 end
 
+@testset "Transform a `EvoTreeRegressor` to a binary `EvoTreeClassifier`" begin
+    include("evotrees.jl")
+end
+
 end
 
 true


### PR DESCRIPTION
For example, this will allow the user to take a `Deterministic` regression model and transform it into a `Probabilistic` binary classification model.

TODO before merging:
- [ ] Remove the `evotrees.jl` tests.
- [ ] Add some simpler tests.