### PR TITLE
Add suggestion to `err_incompatible_prediction_types` message

### DIFF
--- a/src/resampling.jl
+++ b/src/resampling.jl
@@ -39,7 +39,11 @@ err_ambiguous_operation(model, measure) = ArgumentError(
     "\nUnable to deduce an appropriate operation for $measure. "*
     "Explicitly specify `operation=...` or `operations=...`. ")
 err_incompatible_prediction_types(model, measure) = ArgumentError(
-    _ambiguous_operation(model, measure))
+    _ambiguous_operation(model, measure)*
+    "If your model really is making probabilistic predictions, try explicitly "*
+    "specifiying operations. For example, for "*
+    "`measures = [area_under_curve, accuracy]`, try "*
+    "`operations=[predict, predict_mode]`. ")
 
 
 # ==================================================================


### PR DESCRIPTION
User on slack wanted to `evaluate!` a model with a bad `prediction_type`: the model predicts probabilities but the trait `prediction_type` was reporting otherwise. This PR helps such a user discover a workaround.