### PR TITLE
Fix a problem with confmat and CategoricalValue eltype

### DIFF
--- a/src/measures/confusion_matrix.jl
+++ b/src/measures/confusion_matrix.jl
@@ -43,6 +43,10 @@ _categorical(y1::CategoricalArray{V1,N},
              y2::CategoricalArray{V2,N}) where
     {V, V1<:Union{Missing,V}, V2<:Union{Missing,V}, N} =
     y1, y2
+_categorical(y1::AbstractArray{<:CategoricalArrays.CategoricalValue},
+             y2::AbstractArray{<:CategoricalArrays.CategoricalValue}) =
+    broadcast(identity, y1), broadcast(identity, y2)
+
 
 """
     _confmat(ŷ, y; rev=false)

--- a/test/measures/confusion_matrix.jl
+++ b/test/measures/confusion_matrix.jl
@@ -12,6 +12,8 @@ using .Models
     f = categorical(b)
     g = categorical(c)
     h = categorical(d)
+    j = CategoricalArrays.CategoricalValue{Int64, UInt32}[e[1], e[1], e[1], e[1]]
+    k = CategoricalArrays.CategoricalValue{Int64, UInt32}[e[4], e[4], e[4], e[4]]
     rhs = (Set(1:5), Set(1:5))
     @test Set.(levels.(MLJBase._categorical(a, b))) == rhs
     @test Set.(levels.(MLJBase._categorical(a, d))) == rhs
@@ -25,6 +27,11 @@ using .Models
     @test Set.(levels.(MLJBase._categorical(d, c))) == rhs
     @test Set.(levels.(MLJBase._categorical(f, a))) == rhs
     @test Set.(levels.(MLJBase._categorical(h, a))) == rhs
+
+    @test Set.(levels.(MLJBase._categorical(j, k))) == (Set(1:3), Set(1:3))
+
+    # case of ordinary vector with CategoricalValue eltype:
+    acv = CategoricalArrays.CategoricalVector
 end
 
 @testset "basics" begin


### PR DESCRIPTION
This PR addresses a corner case for `confmat(y1, y2)` when `y1` and `y2` have `CategoricalValue` eltype but aren't actually categorical arrays. Previously, the following would fail:

```julia
bag = categorical(collect("abc"));

julia> y = CategoricalArrays.CategoricalValue{Char, UInt32}[bag[1], bag[1]]
2-element Vector{CategoricalValue{Char, UInt32}}:
 'a'
 'a'

julia> confmat(y, y)
┌ Warning: The classes are un-ordered,
│ using order: ['a', 'b', 'c'].
│ To suppress this warning, consider coercing to OrderedFactor.
└ @ MLJBase ~/MLJ/MLJBase/src/measures/confusion_matrix.jl:124
              ┌─────────────────────────────────────────┐
              │              Ground Truth               │
┌─────────────┼─────────────┬─────────────┬─────────────┤
│  Predicted  │      a      │      b      │      c      │
├─────────────┼─────────────┼─────────────┼─────────────┤
│      a      │      2      │      0      │      0      │
├─────────────┼─────────────┼─────────────┼─────────────┤
│      b      │      0      │      0      │      0      │
├─────────────┼─────────────┼─────────────┼─────────────┤
│      c      │      0      │      0      │      0      │
└─────────────┴─────────────┴─────────────┴─────────────┘
```