### PR TITLE
Improve short version of `show` for measures

### DIFF
--- a/src/MLJBase.jl
+++ b/src/MLJBase.jl
@@ -110,7 +110,7 @@ const COLUMN_WIDTH = 24
 # how deep to display fields of `MLJType` objects:
 const DEFAULT_SHOW_DEPTH = 0
 const DEFAULT_AS_CONSTRUCTED_SHOW_DEPTH = 2
-const INDENT = 4
+const INDENT = 2
 
 const Arr = AbstractArray
 const Vec = AbstractVector

--- a/src/machines.jl
+++ b/src/machines.jl
@@ -375,8 +375,10 @@ machines(::Source) = Machine[]
 _cache_status(::Machine{<:Any,true}) = " caches data"
 _cache_status(::Machine{<:Any,false}) = " does not cache data"
 
+Base.show(io::IO, mach::Machine) = print(io, "machine($(mach.model), …)")
 function Base.show(io::IO, ::MIME"text/plain", mach::Machine{M}) where M
-    show(io, mach)
+    #show(io, mach)
+    print(io, "Machine")
     print(io, " trained $(mach.state) time")
     if mach.state == 1
         print(io, ";")
@@ -384,7 +386,7 @@ function Base.show(io::IO, ::MIME"text/plain", mach::Machine{M}) where M
         print(io, "s;")
     end
     println(io, _cache_status(mach))
-    println(io, "  model: $M")
+    println(io, "  model: $(mach.model)")
     println(io, "  args: ")
     for i in eachindex(mach.args)
         arg = mach.args[i]

--- a/src/measures/measures.jl
+++ b/src/measures/measures.jl
@@ -149,8 +149,8 @@ end
 
 # display:
 show_as_constructed(::Type{<:Measure}) = true
-show_compact(::Type{<:Measure}) = true
-Base.show(io::IO, m::Measure) = show(io, MIME("text/plain"), m)
+#show_compact(::Type{<:Measure}) = true
+#Base.show(io::IO, m::Measure) = show(io, MIME("text/plain"), m)
 
 # info
 function StatisticalTraits.info(M::Type{<:Measure})

--- a/src/measures/measures.jl
+++ b/src/measures/measures.jl
@@ -149,8 +149,8 @@ end
 
 # display:
 show_as_constructed(::Type{<:Measure}) = true
-#show_compact(::Type{<:Measure}) = true
-#Base.show(io::IO, m::Measure) = show(io, MIME("text/plain"), m)
+# show_compact(::Type{<:Measure}) = true
+# Base.show(io::IO, m::Measure) = show(io, MIME("text/plain"), m)
 
 # info
 function StatisticalTraits.info(M::Type{<:Measure})

--- a/src/measures/measures.jl
+++ b/src/measures/measures.jl
@@ -149,8 +149,6 @@ end
 
 # display:
 show_as_constructed(::Type{<:Measure}) = true
-# show_compact(::Type{<:Measure}) = true
-# Base.show(io::IO, m::Measure) = show(io, MIME("text/plain"), m)
 
 # info
 function StatisticalTraits.info(M::Type{<:Measure})

--- a/src/resampling.jl
+++ b/src/resampling.jl
@@ -531,7 +531,9 @@ _short(v::Vector) = string("[", join(_short.(v), ", "), "]")
 _short(::Missing) = missing
 
 function Base.show(io::IO, ::MIME"text/plain", e::PerformanceEvaluation)
-    _measure =  e.measure
+    _measure =  map(e.measure) do m
+        repr(MIME("text/plain"), m)
+    end
     _measurement = round3.(e.measurement)
     _per_fold = [round3.(v) for v in e.per_fold]
 
@@ -547,7 +549,8 @@ function Base.show(io::IO, ::MIME"text/plain", e::PerformanceEvaluation)
     color_off()
     PrettyTables.pretty_table(io, data, header;
                               header_crayon=PrettyTables.Crayon(bold=false),
-                              alignment=:l)
+                              alignment=:l,
+                              linebreaks=true)
     show_color ? color_on() : color_off()
 end
 

--- a/src/resampling.jl
+++ b/src/resampling.jl
@@ -531,8 +531,11 @@ _short(v::Vector) = string("[", join(_short.(v), ", "), "]")
 _short(::Missing) = missing
 
 function Base.show(io::IO, ::MIME"text/plain", e::PerformanceEvaluation)
-    data = hcat(e.measure, round3.(e.measurement), e.operation,
-                [round3.(v) for v in e.per_fold])
+    _measure =  e.measure
+    _measurement = round3.(e.measurement)
+    _per_fold = [round3.(v) for v in e.per_fold]
+
+    data = hcat(_measure, _measurement, e.operation, _per_fold)
     header = ["measure", "measurement", "operation", "per_fold"]
     println(io, "PerformanceEvaluation object "*
             "with these fields:")

--- a/src/show.jl
+++ b/src/show.jl
@@ -139,6 +139,16 @@ end
 # short version of showing a `MLJType` object:
 function Base.show(stream::IO, object::MLJType)
     str = simple_repr(typeof(object))
+    L = length(propertynames(object))
+    if L > 0
+        first_name = propertynames(object) |> first
+        value = getproperty(object, first_name)
+        str *= "($first_name = $value"
+        L > 1 && (str *= ", …")
+        str *= ")"
+    else
+        str *= "()"
+    end
     show_handle(object) && (str *= " $(handle(object))")
     if false # !isempty(propertynames(object))
         printstyled(IOContext(stream, :color=> SHOW_COLOR),
@@ -185,9 +195,13 @@ function fancy(stream, object::MLJType, current_depth, depth, n)
             show_compact(object) ||
                 print(stream, crind(n + length(prefix) - anti))
             print(stream, "$(names[k]) = ")
-            fancy(stream, value, current_depth + 1, depth, n + length(prefix)
-                  - anti + length("$k = "))
-            k == n_names || print(stream, ",")
+            if show_compact(object)
+                show(stream, value)
+            else
+                fancy(stream, value, current_depth + 1, depth, n + length(prefix)
+                      - anti + length("$k = "))
+            end
+            k == n_names || print(stream, ", ")
         end
         print(stream, ")")
         if current_depth == 0 && show_handle(object)

--- a/src/show.jl
+++ b/src/show.jl
@@ -120,19 +120,22 @@ show_handle(object) = false
 function simple_repr(T)
     repr = string(T.name.name)
     parameters = T.parameters
-    p_string = ""
-    if length(parameters) > 0
-        p = parameters[1]
-        if p isa DataType
-            p_string = simple_repr(p)
-        elseif p isa Symbol
-            p_string = string(":", p)
-        end
-        if length(parameters) > 1
-            p_string *= ",…"
-        end
-    end
-    isempty(p_string) || (repr *= "{"*p_string*"}")
+
+    # # add abbreviated type parameters:
+    # p_string = ""
+    # if length(parameters) > 0
+    #     p = parameters[1]
+    #     if p isa DataType
+    #         p_string = simple_repr(p)
+    #     elseif p isa Symbol
+    #         p_string = string(":", p)
+    #     end
+    #     if length(parameters) > 1
+    #         p_string *= ",…"
+    #     end
+    # end
+    # isempty(p_string) || (repr *= "{"*p_string*"}")
+
     return repr
 end
 


### PR DESCRIPTION
This PR tweaks a few anomalies for `show(::MLJType)` and attempts to addresses https://github.com/alan-turing-institute/MLJ.jl/issues/923.

**edited to reflect final proposal:**

### models and most other `MLJType` objects

Type parameters now omitted in short display, but first hyper-parameter shown instead, for consistency with the long `MIMIE("text/plain")` display shown first below:

```
julia> Standardizer()
Standardizer(
  features = Symbol[], 
  ignore = false, 
  ordered_factor = false, 
  count = false)

julia> [Standardizer(), ConstantRegressor()]
2-element Vector{Model}:
 Standardizer(features = Symbol[], …)
 ConstantRegressor(distribution_type = Distributions.Normal)
```

### measures

Display like models:

```julia
julia> macro_f1score
MulticlassFScore(
  β = 1.0, 
  average = MLJBase.MacroAvg(), 
  return_type = LittleDict)

julia> [macro_f1score, multiclass_true_positive_rate]
2-element Vector{MLJBase.Aggregated}:
 MulticlassFScore(β = 1.0, …)
 MulticlassTruePositiveRate(average = MLJBase.MacroAvg(), …)
```

### machines

```julia
julia> machine(ConstantRegressor(), make_regression()...)
Machine trained 0 times; caches data
  model: ConstantRegressor(distribution_type = Distributions.Normal)
  args: 
    1:  Source @554 ⏎ `Table{AbstractVector{Continuous}}`
    2:  Source @168 ⏎ `AbstractVector{Continuous}`
```

### performance evaluation tables

```julia
using MLJBase, MLJModels

julia> evaluate(ConstantClassifier(),
       make_moons()...,
       measures=[Accuracy(), MulticlassPrecision(), MulticlassTruePositiveRate()])
PerformanceEvaluation object with these fields:
  measure, measurement, operation, per_fold,
  per_observation, fitted_params_per_fold,
  report_per_fold, train_test_pairs
Extract:
┌─────────────────────────────────────────────────────────────┬─────────────┬───────────────
│ measure                                                     │ measurement │ operation    ⋯
├─────────────────────────────────────────────────────────────┼─────────────┼───────────────
│ Accuracy()                                                  │ 0.407       │ predict_mode ⋯
│ MulticlassPrecision(average = MLJBase.MacroAvg(), …)        │ 0.703       │ predict_mode ⋯
│ MulticlassTruePositiveRate(average = MLJBase.MacroAvg(), …) │ 0.5         │ predict_mode ⋯
└─────────────────────────────────────────────────────────────┴─────────────┴───────────────
```
This last is not ideal (see further discussion below) and may require an evaluation-specific fix. Some discussion below about this. 