### PR TITLE
Fix wrong field name in a `show` method

### DIFF
--- a/src/resampling.jl
+++ b/src/resampling.jl
@@ -538,7 +538,7 @@ function Base.show(io::IO, ::MIME"text/plain", e::PerformanceEvaluation)
             "with these fields:")
     println(io, "  measure, measurement, operation, per_fold,\n"*
             "  per_observation, fitted_params_per_fold,\n"*
-            "  report_per_fold, train_test_pairs")
+            "  report_per_fold, train_test_rows")
     println(io, "Extract:")
     show_color = MLJBase.SHOW_COLOR
     color_off()

--- a/src/resampling.jl
+++ b/src/resampling.jl
@@ -503,9 +503,8 @@ struct.
   machine `mach` training in resampling - one machine per train/test
   pair.
 
-- `train_test_rows`: a vector of vectors containing the train-test
-  pairs used to evaluate the model.
-
+- `train_test_rows`: a vector of tuples, each of the form `(train, test)`, where `train` and `test` 
+   are vectors of row (observation) indices for training and evaluation respectively. 
 """
 struct PerformanceEvaluation{M,
                              Measurement,

--- a/src/resampling.jl
+++ b/src/resampling.jl
@@ -503,6 +503,9 @@ struct.
   machine `mach` training in resampling - one machine per train/test
   pair.
 
+- `train_test_rows`: a vector of vectors containing the train-test
+  pairs used to evaluate the model.
+
 """
 struct PerformanceEvaluation{M,
                              Measurement,
@@ -617,7 +620,7 @@ function _check_measure(measure, operation, model, y)
 
 end
 
-_check_measures(measures, operations, model, y) = begin
+function _check_measures(measures, operations, model, y)
     all(eachindex(measures)) do j
         _check_measure(measures[j], operations[j], model, y)
     end

--- a/test/resampling.jl
+++ b/test/resampling.jl
@@ -766,5 +766,23 @@ end
              measures=[LogLoss(), BrierScore()], verbosity=0)
 end
 
+@testset "reported fields in documentation" begin
+    # Using `evaluate` to obtain a `PerformanceEvaluation` object.
+    clf = ConstantClassifier()
+    X, y = make_moons(100)
+    evaluations = evaluate(clf, X, y, resampling=CV())
+    T = typeof(evaluations)
+    @test T <: PerformanceEvaluation
+
+    show_text = sprint(show, MIME"text/plain"(), evaluations)
+    docstring_text = string(@doc(PerformanceEvaluation))
+    for fieldname in fieldnames(PerformanceEvaluation)
+        @test contains(show_text, string(fieldname))
+        # string(text::Markdown.MD) converts `-` list items to `*`.
+        @test contains(docstring_text, " * `$fieldname`")
+    end
+end
+
 #end
 true
+


### PR DESCRIPTION
According to the `show` output, `PerformanceEvaluation` has a field `train_test_pairs` whereas this should actually be `train_test_rows`.

Should I also add a test to check whether all `fieldnames(PerformanceEvaluation)` are contained in the output of `show`?