### PR TITLE
Add std to show for `PerformanceEvaluation`

### DIFF
--- a/src/resampling.jl
+++ b/src/resampling.jl
@@ -473,7 +473,7 @@ the heading `1.96*SE`, derived from the standard error of the `per_fold`
 entries. This value is suitable for constructing a formal 95%
 confidence interval for the given `measurement`. Such intervals should
 be interpreted with caution. See, for example, Bates et al.
-[2021](https://arxiv.org/abs/2104.00673).
+[(2021)](https://arxiv.org/abs/2104.00673).
 
 ### Fields
 

--- a/src/resampling.jl
+++ b/src/resampling.jl
@@ -533,25 +533,20 @@ _short(v::Vector{<:Real}) = MLJBase.short_string(v)
 _short(v::Vector) = string("[", join(_short.(v), ", "), "]")
 _short(::Missing) = missing
 
-function _fold_std(per_fold::AbstractVector)
-    length(per_fold) == 1 && return nothing
-    return std(per_fold)
-end
-
 function Base.show(io::IO, ::MIME"text/plain", e::PerformanceEvaluation)
     _measure = [repr(MIME("text/plain"), m) for m in e.measure]
     _measurement = round3.(e.measurement)
     _per_fold = [round3.(v) for v in e.per_fold]
-    _std = round3.(_fold_std.(e.per_fold))
+    _std = round3.(std.(e.per_fold))
 
     # Only show the standard deviation if the number of folds is higher than 1.
-    all_nothings = all(_std .=== nothing)
-    data = all_nothings ?
-        hcat(_measure, e.operation, _measurement, _per_fold) :
-        hcat(_measure, e.operation, _measurement, _std, _per_fold)
-    header = all_nothings ?
-        ["measure", "operation", "measurement", "per_fold"] :
-        ["measure", "operation", "measurement", "std", "per_fold"]
+    show_std = any(!isnan, _std)
+    data = show_std ?
+        hcat(_measure, e.operation, _measurement, _std, _per_fold) :
+        hcat(_measure, e.operation, _measurement, _per_fold)
+    header = show_std ?
+        ["measure", "operation", "measurement", "std", "per_fold"] :
+        ["measure", "operation", "measurement", "per_fold"]
 
     println(io, "PerformanceEvaluation object "*
             "with these fields:")

--- a/src/resampling.jl
+++ b/src/resampling.jl
@@ -556,23 +556,14 @@ function Base.show(io::IO, ::MIME"text/plain", e::PerformanceEvaluation)
         hcat(_measure, e.operation, _measurement, _sterr, _per_fold) :
         hcat(_measure, e.operation, _measurement, _per_fold)
     header = show_sterr ?
-        ["measure", "operation", "measurement", "sterr", "per_fold"] :
+        ["measure", "operation", "measurement", "1.96*SE", "per_fold"] :
         ["measure", "operation", "measurement", "per_fold"]
 
     println(io, "PerformanceEvaluation object "*
             "with these fields:")
-    println(io, "  measure, measurement, operation, per_fold,\n"*
+    println(io, "  measure, operation, measurement, per_fold,\n"*
             "  per_observation, fitted_params_per_fold,\n"*
             "  report_per_fold, train_test_rows")
-    if show_sterr
-        println(io, "\nNote. The sterr column gives the standard error \n" *
-            "  over the folds with a 95% confidence interval \n" *
-            "  `(1.96 * std / sqrt(nfolds - 1)`. This number can be useful \n" *
-            "  to get an idea of the variability of the scores, but \n" *
-            "  beware that the estimate shouldn't be used for hypothesis \n" *
-            "  testing (e.g., https://arxiv.org/abs/2104.00673).\n"
-            )
-    end
     println(io, "Extract:")
     show_color = MLJBase.SHOW_COLOR[]
     color_off()

--- a/src/resampling.jl
+++ b/src/resampling.jl
@@ -468,6 +468,13 @@ pairs are recorded in the `train_test_rows` field of the
 aggregated over all train/test pairs, are recorded in `measurement`, a
 vector with one entry for each measure (metric) recorded in `measure`.
 
+When displayed, a `PerformanceEvalution` object includes a value under
+the heading `1.96*SE`, derived from the standard error of the `per_fold`
+entries. This value is suitable for constructing a formal 95%
+confidence interval for the given `measurement`. Such intervals should
+be interpreted with caution. See, for example, Bates et al.
+[2021](https://arxiv.org/abs/2104.00673).
+
 ### Fields
 
 These fields are part of the public API of the `PerformanceEvaluation`

--- a/src/resampling.jl
+++ b/src/resampling.jl
@@ -462,8 +462,8 @@ outlier detection model.
 When `evaluate`/`evaluate!` is called, a number of train/test pairs
 ("folds") of row indices are generated, according to the options
 provided, which are discussed in the [`evaluate!`](@ref)
-doc-string. Rows correspond to observations.  The train/test pairs
-generated are recorded in the `train_test_rows` field of the
+doc-string. Rows correspond to observations. The generated train/test
+pairs are recorded in the `train_test_rows` field of the
 `PerformanceEvaluation` struct, and the corresponding estimates,
 aggregated over all train/test pairs, are recorded in `measurement`, a
 vector with one entry for each measure (metric) recorded in `measure`.
@@ -503,8 +503,9 @@ struct.
   machine `mach` training in resampling - one machine per train/test
   pair.
 
-- `train_test_rows`: a vector of tuples, each of the form `(train, test)`, where `train` and `test` 
-   are vectors of row (observation) indices for training and evaluation respectively. 
+- `train_test_rows`: a vector of tuples, each of the form `(train, test)`,
+  where `train` and `test` are vectors of row (observation) indices for
+  training and evaluation respectively.
 """
 struct PerformanceEvaluation{M,
                              Measurement,
@@ -533,14 +534,13 @@ _short(v::Vector) = string("[", join(_short.(v), ", "), "]")
 _short(::Missing) = missing
 
 function Base.show(io::IO, ::MIME"text/plain", e::PerformanceEvaluation)
-    _measure =  map(e.measure) do m
-        repr(MIME("text/plain"), m)
-    end
+    _measure = [repr(MIME("text/plain"), m) for m in e.measure]
     _measurement = round3.(e.measurement)
     _per_fold = [round3.(v) for v in e.per_fold]
+    _std = round3.(std.(e.per_fold))
 
-    data = hcat(_measure, _measurement, e.operation, _per_fold)
-    header = ["measure", "measurement", "operation", "per_fold"]
+    data = hcat(_measure, e.operation, _measurement, _std, _per_fold)
+    header = ["measure", "operation", "measurement", "std", "per_fold"]
     println(io, "PerformanceEvaluation object "*
             "with these fields:")
     println(io, "  measure, measurement, operation, per_fold,\n"*

--- a/test/resampling.jl
+++ b/test/resampling.jl
@@ -775,6 +775,8 @@ end
     @test T <: PerformanceEvaluation
 
     show_text = sprint(show, MIME"text/plain"(), evaluations)
+    cols = ["measure", "operation", "measurement", "std", "per_fold"]
+    @test all(contains.(show_text, cols))
     print(show_text)
     docstring_text = string(@doc(PerformanceEvaluation))
     for fieldname in fieldnames(PerformanceEvaluation)
@@ -782,6 +784,12 @@ end
         # string(text::Markdown.MD) converts `-` list items to `*`.
         @test contains(docstring_text, " * `$fieldname`")
     end
+
+    measures = [LogLoss(), Accuracy()]
+    evaluations = evaluate(clf, X, y; measures, resampling=Holdout())
+    show_text = sprint(show, MIME"text/plain"(), evaluations)
+    print(show_text)
+    @test !contains(show_text, "std")
 end
 
 #end

--- a/test/resampling.jl
+++ b/test/resampling.jl
@@ -775,6 +775,7 @@ end
     @test T <: PerformanceEvaluation
 
     show_text = sprint(show, MIME"text/plain"(), evaluations)
+    print(show_text)
     docstring_text = string(@doc(PerformanceEvaluation))
     for fieldname in fieldnames(PerformanceEvaluation)
         @test contains(show_text, string(fieldname))

--- a/test/resampling.jl
+++ b/test/resampling.jl
@@ -775,7 +775,7 @@ end
     @test T <: PerformanceEvaluation
 
     show_text = sprint(show, MIME"text/plain"(), evaluations)
-    cols = ["measure", "operation", "measurement", "sterr", "per_fold"]
+    cols = ["measure", "operation", "measurement", "1.96*SE", "per_fold"]
     @test all(contains.(show_text, cols))
     print(show_text)
     docstring_text = string(@doc(PerformanceEvaluation))

--- a/test/resampling.jl
+++ b/test/resampling.jl
@@ -775,7 +775,7 @@ end
     @test T <: PerformanceEvaluation
 
     show_text = sprint(show, MIME"text/plain"(), evaluations)
-    cols = ["measure", "operation", "measurement", "std", "per_fold"]
+    cols = ["measure", "operation", "measurement", "sterr", "per_fold"]
     @test all(contains.(show_text, cols))
     print(show_text)
     docstring_text = string(@doc(PerformanceEvaluation))


### PR DESCRIPTION
Suggestion to add the standard deviation to the `PerformanceEvaluation` output:

```
┌────────────────────────────────┬───────────┬─────────────┬────────┬──────────────────────────────────────┐
│ measure                        │ operation │ measurement │ std    │ per_fold                             │
├────────────────────────────────┼───────────┼─────────────┼────────┼──────────────────────────────────────┤
│ LogLoss(                       │ predict   │ 0.704       │ 0.0135 │ [0.732, 0.7, 0.7, 0.7, 0.696, 0.696] │
│   tol = 2.220446049250313e-16) │           │             │        │                                      │
└────────────────────────────────┴───────────┴─────────────┴────────┴──────────────────────────────────────┘
```
This is useful to spot more easily how much variation there is on the reported measurement.