### PR TITLE
Fix bugs and inconsistencies in documentation on `evaluate!`s `resampling` keyword

### DIFF
--- a/src/resampling.jl
+++ b/src/resampling.jl
@@ -827,11 +827,11 @@ measure or vector.
 
 Do `subtypes(MLJ.ResamplingStrategy)` to obtain a list of available
 resampling strategies. If `resampling` is not an object of type
-`MLJ.ResamplingStrategy`, then a vector of pairs (of the form
+`MLJ.ResamplingStrategy`, then a vector of tuples (of the form
 `(train_rows, test_rows)` is expected. For example, setting
 
-    resampling = [(1:100), (101:200)),
-                   (101:200), (1:100)]
+    resampling = [((1:100), (101:200)),
+                   ((101:200), (1:100))]
 
 gives two-fold cross-validation using the first 200 rows of data.
 

--- a/src/resampling.jl
+++ b/src/resampling.jl
@@ -1164,7 +1164,7 @@ function evaluate!(mach::Machine, resampling, weights,
 
     if !(resampling isa TrainTestPairs)
         error("`resampling` must be an "*
-              "`MLJ.ResamplingStrategy` or tuple of pairs "*
+              "`MLJ.ResamplingStrategy` or tuple of rows "*
               "of the form `(train_rows, test_rows)`")
     end
 


### PR DESCRIPTION
This pull request contains minor changes in `resampling.jl`.
The changes const of:
1. Fixing a bug in the `resampling` code example showing a vector of tuples
2. Improve the documentation to use "vector of tuples" instead of "vector of pairs" to prevent confusion with the `Pair` datatype
3. Improve the error message in case a wrong type was supplied for the `resampling` keyword