### PR TITLE
Remove apparatus to anonymize composite model fitresults

### DIFF
--- a/src/composition/models/methods.jl
+++ b/src/composition/models/methods.jl
@@ -28,8 +28,7 @@ function update(model::M,
 
     # Otherwise, a "smart" fit is carried out by calling `fit!` on a
     # greatest lower bound node for nodes in the signature of the
-    # underlying learning network machine. For this it is necessary to
-    # temporarily "de-anonymize" the source nodes.
+    # underlying learning network machine.
 
     network_model_names = getfield(fitresult, :network_model_names)
     old_model = cache.old_model
@@ -40,26 +39,13 @@ function update(model::M,
         return fit(model, verbosity, args...)
     end
 
-    # return data to source nodes for fitting:
-    sources, data = cache.sources, cache.data
-    for k in eachindex(sources)
-        rebind!(sources[k], data[k])
-    end
-
     fit!(glb_node; verbosity=verbosity)
     # Retrieve additional report values
     report_additions_ = _call(_report_part(signature(fitresult)))
 
-    # anonymize data again:
-    for s in sources
-        rebind!(s, nothing)
-    end
-
     # record current model state:
-    cache = (sources=cache.sources,
-             data=cache.data,
-             old_model = deepcopy(model))
-    
+    cache = (; old_model = deepcopy(model))
+
     return (fitresult,
             cache,
             merge(report(glb_node), report_additions_))

--- a/test/composition/models/from_network.jl
+++ b/test/composition/models/from_network.jl
@@ -295,11 +295,6 @@ knn = model_.knn_rgs
 
 @test MLJBase.tree(mach.fitresult.predict).arg1.arg1.arg1.arg1.model.K == 55
 
-# check data anonymity:
-@test all(x->(x===nothing),
-          [s.data for s in sources(mach.fitresult.predict)])
-
-
 multistand = Standardizer()
 multistandM = machine(multistand, W)
 W2 = transform(multistandM, W)
@@ -327,10 +322,6 @@ hot = model_.one_hot
 FP = MLJBase.fitted_params(mach)
 @test keys(FP) == (:one_hot, :machines, :fitted_params_given_machine)
 @test Set(FP.one_hot.fitresult.all_features) == Set(keys(X))
-
-# check data anomynity:
-@test all(x->(x===nothing),
-          [s.data for s in sources(mach.fitresult.transform)])
 
 transform(mach, X);
 

--- a/test/composition/models/methods.jl
+++ b/test/composition/models/methods.jl
@@ -128,10 +128,6 @@ selector_model = FeatureSelector()
 
     fitresult, cache, rep = MLJBase.fit(composite, 0, Xtrain, ytrain);
 
-    # test data anonymity:
-    ss = sources(glb(values(MLJBase.signature(fitresult))...))
-    @test all(isempty, ss)
-
     # to check internals:
     ridge = MLJBase.machines(fitresult.predict)[1]
     selector = MLJBase.machines(fitresult.predict)[2]


### PR DESCRIPTION
Traces of data in machines are now removed at time of serialisation (see [docs](https://alan-turing-institute.github.io/MLJ.jl/dev/machines/#Saving-machines)). Carried over from the old way of handling data anonymization there remains some gymnastics to shift data in and out of sources nodes in the learning networks used in composite models. This PR removes this redundant code and testing.

@olivierlabayle 