### PR TITLE
Add `feature_importances` machine inspection method.

### DIFF
--- a/src/MLJBase.jl
+++ b/src/MLJBase.jl
@@ -258,7 +258,7 @@ export @mlj_model, metadata_pkg, metadata_model
 export fit, update, update_data, transform, inverse_transform,
     fitted_params, predict, predict_mode, predict_mean,
     predict_median, predict_joint,
-    evaluate, clean!, training_losses, intrinsic_importances
+    evaluate, clean!, training_losses, feature_importances
 
 # data operations
 export matrix, int, classes, decoder, table,

--- a/src/MLJBase.jl
+++ b/src/MLJBase.jl
@@ -53,7 +53,7 @@ import MLJModelInterface: fit, update, update_data, transform,
     predict_mean, predict_median, predict_joint,
     evaluate, clean!, is_same_except,
     save, restore, is_same_except, istransparent,
-    params, training_losses, intrinsic_importances
+    params, training_losses, feature_importances
 
 # Macros
 using Parameters

--- a/src/MLJBase.jl
+++ b/src/MLJBase.jl
@@ -258,7 +258,7 @@ export @mlj_model, metadata_pkg, metadata_model
 export fit, update, update_data, transform, inverse_transform,
     fitted_params, predict, predict_mode, predict_mean,
     predict_median, predict_joint,
-    evaluate, clean!, training_losses
+    evaluate, clean!, training_losses, intrinsic_importances
 
 # data operations
 export matrix, int, classes, decoder, table,

--- a/src/MLJBase.jl
+++ b/src/MLJBase.jl
@@ -53,7 +53,7 @@ import MLJModelInterface: fit, update, update_data, transform,
     predict_mean, predict_median, predict_joint,
     evaluate, clean!, is_same_except,
     save, restore, is_same_except, istransparent,
-    params, training_losses
+    params, training_losses, intrinsic_importances
 
 # Macros
 using Parameters

--- a/src/machines.jl
+++ b/src/machines.jl
@@ -824,11 +824,12 @@ end
 """
     feature_importances(mach::Machine)
 
-Return a list of feature => importance pairs for a fitted machine, `mach` if it's underlying model 
-supports intrinsic feature importances. Otherwise, returns `nothing`.
+Return a list of `feature => importance` pairs for a fitted machine, 
+`mach`,  if supported by the underlying model, i.e., if 
+`reports_feature_importances(mach.model) == true`.  Otherwise return
+`nothing`.
 
 """
-
 function feature_importances(mach::Machine)
     if isdefined(mach, :report) && isdefined(mach, :fitresult)
         return _feature_importances(mach.model, mach.fitresult, mach.report)

--- a/src/machines.jl
+++ b/src/machines.jl
@@ -822,18 +822,18 @@ function training_losses(mach::Machine)
 end
 
 """
-    intrinsic_importances(mach::Machine)
+    feature_importances(mach::Machine)
 
 Return a list of feature => importance pairs for a fitted machine, `mach` if it's underlying model 
 supports intrinsic feature importances. Otherwise, returns `nothing`.
 
 """
 
-function intrinsic_importances(mach::Machine)
+function feature_importances(mach::Machine)
     if isdefined(mach, :report) && isdefined(mach, :fitresult)
-        return MMI.intrinsic_importances(mach.model, mach.fitresult, mach.report)
+        return MMI.feature_importances(mach.model, mach.fitresult, mach.report)
     else
-        throw(NotTrainedError(mach, :intrinsic_importances))
+        throw(NotTrainedError(mach, :feature_importances))
     end
 end
 

--- a/src/machines.jl
+++ b/src/machines.jl
@@ -821,6 +821,21 @@ function training_losses(mach::Machine)
     end
 end
 
+"""
+    intrinsic_importances(mach::Machine)
+
+Return a list of feature => importance pairs for a fitted machine, `mach` if it's underlying model 
+supports intrinsic feature importances. Otherwise, returns `nothing`.
+
+"""
+
+function intrinsic_importances(mach::Machine)
+    if isdefined(mach, :report) && isdefined(mach, :fitresult)
+        return MMI.intrinsic_importances(mach.model, mach.fitresult, mach.report)
+    else
+        throw(NotTrainedError(mach, :feature_importances))
+    end
+end
 
 ###############################################################################
 #####    SERIALIZABLE, RESTORE!, SAVE AND A FEW UTILITY FUNCTIONS         #####

--- a/src/machines.jl
+++ b/src/machines.jl
@@ -831,12 +831,19 @@ supports intrinsic feature importances. Otherwise, returns `nothing`.
 
 function feature_importances(mach::Machine)
     if isdefined(mach, :report) && isdefined(mach, :fitresult)
-        return MMI.feature_importances(mach.model, mach.fitresult, mach.report)
+        return _feature_importances(mach.model, mach.fitresult, mach.report)
     else
         throw(NotTrainedError(mach, :feature_importances))
     end
 end
 
+function _feature_importances(model, fitresult, report)
+    if reports_feature_importances(model)
+        return MMI.feature_importances(mach.model, fitresult, report)
+    else
+        return nothing
+    end
+end
 ###############################################################################
 #####    SERIALIZABLE, RESTORE!, SAVE AND A FEW UTILITY FUNCTIONS         #####
 ###############################################################################

--- a/src/machines.jl
+++ b/src/machines.jl
@@ -833,7 +833,7 @@ function intrinsic_importances(mach::Machine)
     if isdefined(mach, :report) && isdefined(mach, :fitresult)
         return MMI.intrinsic_importances(mach.model, mach.fitresult, mach.report)
     else
-        throw(NotTrainedError(mach, :feature_importances))
+        throw(NotTrainedError(mach, :intrinsic_importances))
     end
 end
 

--- a/test/machines.jl
+++ b/test/machines.jl
@@ -52,9 +52,7 @@ end
     @test fitted_params(t) == MMI.fitted_params(t.model, t.fitresult)
     @test report(t) == t.report
     @test training_losses(t) === nothing
-    @test feature_importances(t) == MMI.feature_importances(
-        t.model, t.fitresult, t.report
-    )
+    @test feature_importances(t) === nothing
 
     predict(t, selectrows(X,test));
     @test rms(predict(t, selectrows(X, test)), y[test]) < std(y)

--- a/test/machines.jl
+++ b/test/machines.jl
@@ -39,7 +39,7 @@ end
     @test_throws MLJBase.NotTrainedError(t, :fitted_params) fitted_params(t)
     @test_throws MLJBase.NotTrainedError(t, :report) report(t)
     @test_throws MLJBase.NotTrainedError(t, :training_losses) training_losses(t)
-    @test_throws MLJBase.NotTrainedError(t, :training_losses) intrinsic_importances(t)
+    @test_throws MLJBase.NotTrainedError(t, :intrinsic_importances) intrinsic_importances(t)
 
     @test_logs (:info, r"Training") fit!(t)
     @test_logs (:info, r"Training") fit!(t, rows=train)
@@ -49,8 +49,8 @@ end
     @test_logs (:info, r"Updating") fit!(t)
 
     # The following tests only pass when machine `t` has been fitted 
-    @test fitted_params(t) == MMI.fitted_params(mach.model, mach.fitresult)
-    @test report(t) == mach.report
+    @test fitted_params(t) == MMI.fitted_params(t.model, t.fitresult)
+    @test report(t) == t.report
     @test training_losses(t) === nothing
     @test intrinsic_importances(t) == MMI.intrinsic_importances(
         t.model, fitted_params(t), report(t)

--- a/test/machines.jl
+++ b/test/machines.jl
@@ -53,7 +53,7 @@ end
     @test report(t) == t.report
     @test training_losses(t) === nothing
     @test intrinsic_importances(t) == MMI.intrinsic_importances(
-        t.model, fitted_params(t), report(t)
+        t.model, t.fitresult, t.report
     )
 
     predict(t, selectrows(X,test));

--- a/test/machines.jl
+++ b/test/machines.jl
@@ -39,7 +39,7 @@ end
     @test_throws MLJBase.NotTrainedError(t, :fitted_params) fitted_params(t)
     @test_throws MLJBase.NotTrainedError(t, :report) report(t)
     @test_throws MLJBase.NotTrainedError(t, :training_losses) training_losses(t)
-    @test_throws MLJBase.NotTrainedError(t, :intrinsic_importances) intrinsic_importances(t)
+    @test_throws MLJBase.NotTrainedError(t, :feature_importances) feature_importances(t)
 
     @test_logs (:info, r"Training") fit!(t)
     @test_logs (:info, r"Training") fit!(t, rows=train)
@@ -52,7 +52,7 @@ end
     @test fitted_params(t) == MMI.fitted_params(t.model, t.fitresult)
     @test report(t) == t.report
     @test training_losses(t) === nothing
-    @test intrinsic_importances(t) == MMI.intrinsic_importances(
+    @test feature_importances(t) == MMI.feature_importances(
         t.model, t.fitresult, t.report
     )
 


### PR DESCRIPTION
This PR implements `feature_importances` method that returns a list of feature=>importance pairs for fitted machines with underlying models that supports intrinsic feature importances. (i.e models that overload the `reports_feature_importances` trait.)

**This Requires**
- [x] https://github.com/JuliaAI/MLJModelInterface.jl/pull/148