### PR TITLE
Fix `inverse_transform` bug for pipelines with `Static` components

### DIFF
--- a/src/composition/models/pipelines.jl
+++ b/src/composition/models/pipelines.jl
@@ -487,14 +487,11 @@ function pipeline_network_machine(super_type,
     final_front = foldl(_extend, components, init=front)
     pnode, tnode = final_front.predict, final_front.transform
 
-    # backwards pass to get `inverse_transform` node:
+    # `inverse_transform` node (constructed even if not supported for some component):
     if all(c -> c isa Unsupervised, components)
         inode = source0
-        node = tnode
-        for i in eachindex(components)
-            mach = node.machine
+        for mach in machines(tnode)
             inode = inverse_transform(mach, inode)
-            node =  first(mach.args)
         end
         return machine(super_type(), source0, sources...;
                        predict=pnode, transform=tnode, inverse_transform=inode)

--- a/src/machines.jl
+++ b/src/machines.jl
@@ -337,23 +337,25 @@ See also [`fit!`](@ref), [`default_scitype_check_level`](@ref),
 """
 function machine end
 
+const ERR_STATIC_ARGUMENTS = ArgumentError(
+    "A `Static` transformer "*
+    "has no training arguments. "*
+    "Use `machine(model)`. "
+)
+
 machine(T::Type{<:Model}, args...; kwargs...) =
     throw(ArgumentError("Model *type* provided where "*
                         "model *instance* expected. "))
 
-static_error() =
-    throw(ArgumentError("A `Static` transformer "*
-                        "has no training arguments. "*
-                        "Use `machine(model)`. "))
 
-function machine(model::Static, args...; kwargs...)
-    isempty(args) || static_error()
-    return Machine(model; kwargs...)
+function machine(model::Static, args...; cache=false, kwargs...)
+    isempty(args) || throw(ERR_STATIC_ARGUMENTS)
+    return fit!(Machine(model; cache=false, kwargs...), verbosity=0)
 end
 
-function machine(model::Static, args::AbstractNode...; kwargs...)
-    isempty(args) || static_error()
-    return Machine(model; kwargs...)
+function machine(model::Static, args::AbstractNode...; cache=false, kwargs...)
+    isempty(args) || throw(ERR_STATIC_ARGUMENTS)
+    return fit!(Machine(model; cache=false, kwargs...), verbosity=0)
 end
 
 machine(model::Model, raw_arg1, arg2::AbstractNode, args::AbstractNode...;
@@ -547,7 +549,7 @@ In any of the cases (i) - (iv), `mach` is trained ab initio. If only
 To freeze or unfreeze `mach`, use `freeze!(mach)` or `thaw!(mach)`.
 
 
-### Implementation detail
+### Implementation details
 
 The data to which a machine is bound is stored in `mach.args`. Each
 element of `args` is either a `Node` object, or, in the case that

--- a/src/operations.jl
+++ b/src/operations.jl
@@ -91,7 +91,6 @@ for operation in OPERATIONS
         end
 
         function $operation(mach::Machine{<:Static}, Xraw, Xraw_more...)
-            isdefined(mach, :fitresult) || (mach.fitresult = nothing)
             return $(operation)(mach.model, mach.fitresult,
                                     Xraw, Xraw_more...)
         end

--- a/test/_models/Constant.jl
+++ b/test/_models/Constant.jl
@@ -180,26 +180,22 @@ metadata_model(ConstantRegressor,
                input=MMI.Table,
                target=AbstractVector{MMI.Continuous},
                weights=false,
-               descr="Constant regressor (Probabilistic).",
                path="MLJModels.ConstantRegressor")
 
 metadata_model(DeterministicConstantRegressor,
                input=MMI.Table,
                target=AbstractVector{MMI.Continuous},
                weights=false,
-               descr="Constant regressor (Deterministic).",
                path="MLJModels.DeterministicConstantRegressor")
 
 metadata_model(ConstantClassifier,
                input=MMI.Table,
                target=AbstractVector{<:MMI.Finite},
                weights=true,
-               descr="Constant classifier (Probabilistic).",
                path="MLJModels.ConstantClassifier")
 
 metadata_model(DeterministicConstantClassifier,
                input=MMI.Table,
                target=AbstractVector{<:MMI.Finite},
                weights=false,
-               descr="Constant classifier (Deterministic).",
                path="MLJModels.DeterministicConstantClassifier")

--- a/test/_models/DecisionTree.jl
+++ b/test/_models/DecisionTree.jl
@@ -209,11 +209,9 @@ metadata_pkg.((DecisionTreeClassifier, DecisionTreeRegressor),
 metadata_model(DecisionTreeClassifier,
                input=MLJBase.Table(Continuous, Count, OrderedFactor),
                target=AbstractVector{<:MLJBase.Finite},
-               weights=false,
-               descr=DTC_DESCR)
+               weights=false,)
 
 metadata_model(DecisionTreeRegressor,
                input=MLJBase.Table(Continuous, Count, OrderedFactor),
                target=AbstractVector{MLJBase.Continuous},
-               weights=false,
-               descr=DTR_DESCR)
+               weights=false,)

--- a/test/_models/MultivariateStats.jl
+++ b/test/_models/MultivariateStats.jl
@@ -134,11 +134,9 @@ metadata_pkg.((RidgeRegressor, PCA),
 metadata_model(RidgeRegressor,
                input=MLJBase.Table(MLJBase.Continuous),
                target=AbstractVector{MLJBase.Continuous},
-               weights=false,
-               descr=RIDGE_DESCR)
+               weights=false,)
 
 metadata_model(PCA,
                input=MLJBase.Table(MLJBase.Continuous),
                target=MLJBase.Table(MLJBase.Continuous),
-               weights=false,
-               descr=PCA_DESCR)
+               weights=false,)

--- a/test/_models/NearestNeighbors.jl
+++ b/test/_models/NearestNeighbors.jl
@@ -174,12 +174,10 @@ metadata_model(KNNRegressor,
     input=MLJBase.Table(MLJBase.Continuous),
     target=AbstractVector{MLJBase.Continuous},
     weights=true,
-    descr=KNNRegressorDescription
     )
 
 metadata_model(KNNClassifier,
     input=MLJBase.Table(MLJBase.Continuous),
     target=AbstractVector{<:MLJBase.Finite},
     weights=true,
-    descr=KNNClassifierDescription
     )

--- a/test/_models/Transformers.jl
+++ b/test/_models/Transformers.jl
@@ -583,40 +583,34 @@ metadata_model(FeatureSelector,
                input=MLJBase.Table,
                output=MLJBase.Table,
                weights=false,
-               descr=FEATURE_SELECTOR_DESCR,
                path="MLJBase.FeatureSelector")
 
 metadata_model(UnivariateDiscretizer,
                input=AbstractVector{<:MLJBase.Continuous},
                output=AbstractVector{<:MLJBase.OrderedFactor},
                weights=false,
-               descr=UNIVARIATE_DISCR_DESCR,
                path="MLJBase.UnivariateDiscretizer")
 
 metadata_model(UnivariateStandardizer,
                input=AbstractVector{<:MLJBase.Infinite},
                output=AbstractVector{MLJBase.Continuous},
                weights=false,
-               descr=UNIVARIATE_STD_DESCR,
                path="MLJBase.UnivariateStandardizer")
 
 metadata_model(Standardizer,
                input=MLJBase.Table,
                output=MLJBase.Table,
                weights=false,
-               descr=STANDARDIZER_DESCR,
                path="MLJBase.Standardizer")
 
 metadata_model(UnivariateBoxCoxTransformer,
                input=AbstractVector{MLJBase.Continuous},
                output=AbstractVector{MLJBase.Continuous},
                weights=false,
-               descr=UNIVARIATE_BOX_COX_DESCR,
                path="MLJBase.UnivariateBoxCoxTransformer")
 
 metadata_model(OneHotEncoder,
                input=MLJBase.Table,
                output=MLJBase.Table,
                weights=false,
-               descr=ONE_HOT_DESCR,
                path="MLJBase.OneHotEncoder")

--- a/test/composition/models/pipelines.jl
+++ b/test/composition/models/pipelines.jl
@@ -588,7 +588,8 @@ end
 
 @testset "inverse transform for pipes with static components" begin
     X = randn(rng, 20)
-    pipe = StaticKefir(3) |> Standardizer() |> StaticKefir(5) |> Standardizer()
+    pipe = StaticKefir(3) |> UnivariateStandardizer() |>
+        StaticKefir(5) |> UnivariateStandardizer()
 
     mach = machine(pipe, X)
     fit!(mach, verbosity=0)

--- a/test/composition/models/pipelines.jl
+++ b/test/composition/models/pipelines.jl
@@ -53,10 +53,12 @@ end
 mutable struct StaticKefir <: Static
     alpha::Float64 # non-zero to be invertible
 end
-kefir(X, alpha) = X > 0 ? X * alpha : X / alpha
 
-MLJBase.transform(model::StaticKefir, _, X) = kefir(model.alpha, X)
-MLJBase.inverse_transform(model::StaticKefir, _, W) = kefir(1/(model.alpha), W)
+# for `alpha != 0` the map `x -> kefir(x, alpha) is invertible:
+kefir(x, alpha) = x > 0 ? x * alpha : x / alpha
+
+MLJBase.transform(model::StaticKefir, _, X) = broadcast(kefir, model.alpha, X)
+MLJBase.inverse_transform(model::StaticKefir, _, W) = broadcast(kefir, 1/(model.alpha), W)
 
 d = MyDeterministic(:d)
 p = MyProbabilistic(:p)


### PR DESCRIPTION
Previously the following code threw an error:

```julia
using MLJBase, MLJModels

mutable struct StaticKefir <: Static
    alpha::Float64 # non-zero to be invertible
end

# for `alpha != 0` the map `x -> kefir(x, alpha)` is invertible:
kefir(x, alpha) = x > 0 ? x * alpha : x / alpha

MLJBase.transform(model::StaticKefir, _, X) = broadcast(kefir, model.alpha, X)
MLJBase.inverse_transform(model::StaticKefir, _, W) = broadcast(kefir, 1/(model.alpha), W)

X = randn(20)
pipe = StaticKefir(3) |> Standardizer() |> StaticKefir(5) |> Standardizer()

mach = machine(pipe, X)
fit!(mach, verbosity=0)
```

This PR resolves the error. Behaviour is as expected, as seen from added tests:

```julia
    @test inverse_transform(mach, transform(mach, X)) ≈ X
    @test transform(mach, inverse_transform(mach, X)) ≈ X
```

This PR also changes the machine constructor for `Static` models so that they are `fit!` at construction time. Previously, a `nothing` fitresult was added to the machine the first time `transform` was called on the machine.
