### PR TITLE
Fix bug around training losses for pipelines

### DIFF
--- a/src/composition/models/pipelines.jl
+++ b/src/composition/models/pipelines.jl
@@ -609,6 +609,6 @@ MMI.target_scitype(p::SupervisedPipeline) = target_scitype(supervised_component(
 
 function MMI.training_losses(pipe::SupervisedPipeline, pipe_report)
     mach = supervised(pipe_report.basic.machines)
-    _report = report(mach)
+    _report = mach.report
     return training_losses(mach.model, _report)
 end

--- a/src/composition/models/transformed_target_model.jl
+++ b/src/composition/models/transformed_target_model.jl
@@ -224,8 +224,6 @@ end
 # # TRAINING LOSSES
 
 function training_losses(model::SomeTT, tt_report)
-    @show keys(tt_report)
-    @show model
     mach = first(tt_report.basic.machines)
     return training_losses(mach)
 end

--- a/src/composition/models/transformed_target_model.jl
+++ b/src/composition/models/transformed_target_model.jl
@@ -224,6 +224,8 @@ end
 # # TRAINING LOSSES
 
 function training_losses(model::SomeTT, tt_report)
+    @show keys(tt_report)
+    @show model
     mach = first(tt_report.basic.machines)
     return training_losses(mach)
 end

--- a/test/composition/models/pipelines.jl
+++ b/test/composition/models/pipelines.jl
@@ -355,16 +355,19 @@ end
 
 @testset "training_losses" begin
     model = MyDeterministic(:bla)
-    pipe = Standardizer() |> model
+    tmodel = TransformedTargetModel(model, target=UnivariateStandardizer)
+    pipe = Standardizer() |> tmodel
 
     # test helpers:
-    @test MLJBase.supervised_component_name(pipe) == :my_deterministic
-    @test MLJBase.supervised_component(pipe) == model
+    @test MLJBase.supervised_component_name(pipe) ==
+        :transformed_target_model_deterministic
+    @test MLJBase.supervised_component(pipe) == tmodel
 
     @test supports_training_losses(pipe)
     _, _, rp = MLJBase.fit(pipe, 0, X, y)
     @test training_losses(pipe, rp) == ones(3)
-    @test iteration_parameter(pipe) == :(my_deterministic.x)
+    @test iteration_parameter(pipe) ==
+        :(transformed_target_model_deterministic.model.x)
 end
 
 


### PR DESCRIPTION
After this PR, the following code works again:

```julia
mutable struct MyDeterministic <: Deterministic
    x::Symbol
end

MLJBase.fit(::MyDeterministic, args...) = nothing, nothing, nothing
MLJBase.predict(m::MyDeterministic, ::Any, Xnew) = fill(:dp, nrows(Xnew))
MLJBase.supports_training_losses(::Type{<:MyDeterministic}) = true
MLJBase.iteration_parameter(::Type{<:MyDeterministic}) = :x
MLJBase.training_losses(::MyDeterministic, report) = ones(3)

model = MyDeterministic(:bla)
tmodel = TransformedTargetModel(model, target=Standardizer)
pipe = Standardizer() |> tmodel
__, _, rp = MLJBase.fit(pipe, 0, X, y)
training_losses(pipe, rp)

ERROR: type NamedTuple has no field basic
Stacktrace:
 [1] getproperty
   @ ./Base.jl:42 [inlined]
 [2] training_losses(model::MLJBase.TransformedTargetModelDeterministic{MyDeterministic}, tt_report::NamedTuple{(:model, :machines, :report_given_machine), Tuple{Nothing, Vector{Machine}, OrderedCollections.LittleDict{Any, Any, Vector{Any}, Vector{Any}}}})
   @ MLJBase ~/MLJ/MLJBase/src/composition/models/transformed_target_model.jl:229
 [3] training_losses(pipe::MLJBase.DeterministicPipeline{NamedTuple{(:standardizer, :transformed_target_model_deterministic), Tuple{Unsupervised, Deterministic}}, MLJModelInterface.predict}, pipe_report::NamedTuple{(:basic, :additions), Tuple{NamedTuple{(:machines, :report_given_machine), Tuple{Vector{Machine}, OrderedCollections.LittleDict{Any, Any, Vector{Any}, Vector{Any}}}}, NamedTuple{(), Tuple{}}}})
   @ MLJBase ~/MLJ/MLJBase/src/composition/models/pipelines.jl:613
 [4] top-level scope
   @ REPL[117]:1
 [5] top-level scope
   @ ~/.julia/packages/CUDA/DfvRa/src/initialization.jl:52
```

