### PR TITLE
Overload all operations (`predict`, `predict_mode`, etc) for use on `Static` machines

### DIFF
--- a/src/operations.jl
+++ b/src/operations.jl
@@ -23,7 +23,8 @@
 ## predict(::Machine, ) and transform(::Machine, )
 
 _err_rows_not_allowed() =
-    throw(ArgumentError("Calling `transform(mach, rows=...)` when "*
+    throw(ArgumentError("Calling `transform(mach, rows=...)` or "*
+                        "`predict(mach, rows=...)` when "*
                         "`mach.model isa Static` is not allowed, as no data "*
                         "is bound to `mach` in this case. Specify a explicit "*
                         "data or node, as in `transform(mach, X)`, or "*
@@ -80,13 +81,13 @@ for operation in OPERATIONS
             )
             return get!(ret, $quoted_operation, mach)
         end
+
+        # special case of Static models (no training arguments):
+        $operation(mach::Machine{<:Static}; rows=:) = _err_rows_not_allowed()
     end
     eval(ex)
 
 end
-
-# special case of Static models (no training arguments):
-transform(mach::Machine{<:Static}; rows=:) = _err_rows_not_allowed()
 
 inverse_transform(mach::Machine; rows=:) =
             throw(ArgumentError("`inverse_transform(mach)` and "*

--- a/test/composition/models/static_transformers.jl
+++ b/test/composition/models/static_transformers.jl
@@ -16,7 +16,7 @@ end
 MLJBase.transform(transf::PlainTransformer, verbosity, X) =
     selectcols(X, transf.ftr)
 
-@testset "nodal machine constructor for static transformers" begin
+@testset "machine constructor for static transformers" begin
     X = (x1=rand(3), x2=[1, 2, 3]);
     mach = machine(PlainTransformer(:x2))
     @test transform(mach, X) == [1, 2, 3]
@@ -31,10 +31,14 @@ MLJBase.reporting_operations(::Type{<:YourTransformer}) = (:transform,)
 MLJBase.transform(transf::YourTransformer, verbosity, X) =
     (selectcols(X, transf.ftr), (; nrows=nrows(X)))
 
+MLJBase.predict(transf::YourTransformer, verbosity, X) =
+    collect(1:nrows(X)) |> reverse
+
 @testset "nodal machine constructor for static transformers" begin
     X = (x1=rand(3), x2=[1, 2, 3]);
     mach = machine(YourTransformer(:x2))
     @test transform(mach, X) == [1, 2, 3]
+    @test predict(mach, X) == [3, 2, 1]
     @test report(mach).nrows == 3
     transform(mach, (x2=["a", "b"],))
     @test report(mach).nrows == 2


### PR DESCRIPTION
At present only `transform` is overloaded. In clustering algorithms that do not generalize to new data, such as DBSCAN, we also need `predict`, for consistency with clustering models that *do* generalize (as `transform` is "reserved" for dimension reduction). This PR overloads all operations that can be called on `Static` models to work for `Static` machines as well. 