### PR TITLE
Improve warning of machine constructor

### DIFF
--- a/src/composition/models/stacking.jl
+++ b/src/composition/models/stacking.jl
@@ -116,105 +116,6 @@ const Stack{modelnames, inp_scitype, tg_scitype} = Union{
     ProbabilisticStack{modelnames, inp_scitype, tg_scitype}
 }
 
-"""
-    Stack(; metalearner=nothing, name1=model1, name2=model2, ..., keyword_options...)
-
-Implements the two-layer generalized stack algorithm introduced by
-[Wolpert
-(1992)](https://www.sciencedirect.com/science/article/abs/pii/S0893608005800231)
-and generalized by [Van der Laan et al
-(2007)](https://biostats.bepress.com/ucbbiostat/paper222/). Returns an
-instance of type `ProbabilisticStack` or `DeterministicStack`,
-depending on the prediction type of `metalearner`.
-
-When training a machine bound to such an instance:
-
-- The data is split into training/validation sets according to the
-  specified `resampling` strategy.
-
-- Each base model `model1`, `model2`, ... is trained on each training
-  subset and outputs predictions on the corresponding validation
-  sets. The multi-fold predictions are spliced together into a
-  so-called out-of-sample prediction for each model.
-
-- The adjudicating model, `metalearner`, is subsequently trained on
-  the out-of-sample predictions to learn the best combination of base
-  model predictions.
-
-- Each base model is retrained on all supplied data for purposes of
-  passing on new production data onto the adjudicator for making new
-  predictions
-
-### Arguments
-
-- `metalearner::Supervised`: The model that will optimize the desired
-  criterion based on its internals.  For instance, a LinearRegression
-  model will optimize the squared error.
-
-- `resampling`: The resampling strategy used
-  to prepare out-of-sample predictions of the base learners.
-
-- `measures`: A measure or iterable over measures, to perform an internal
-  evaluation of the learners in the Stack while training. This is not for the
-  evaluation of the Stack itself.
-
-- `cache`: Whether machines created in the learning network will cache data or not.
-
-- `acceleration`: A supported `AbstractResource` to define the training parallelization
-  mode of the stack.
-
-- `name1=model1, name2=model2, ...`: the `Supervised` model instances
-  to be used as base learners.  The provided names become properties
-  of the instance created to allow hyper-parameter access
-
-
-### Example
-
-The following code defines a `DeterministicStack` instance for
-learning a `Continuous` target, and demonstrates that:
-
-- Base models can be `Probabilistic` models even if the stack
-  itself is `Deterministic` (`predict_mean` is applied in such cases).
-
-- As an alternative to hyperparameter optimization, one can stack
-  multiple copies of given model, mutating the hyper-parameter used in
-  each copy.
-
-
-```julia
-using MLJ
-
-DecisionTreeRegressor = @load DecisionTreeRegressor pkg=DecisionTree
-EvoTreeRegressor = @load EvoTreeRegressor
-XGBoostRegressor = @load XGBoostRegressor
-KNNRegressor = @load KNNRegressor pkg=NearestNeighborModels
-LinearRegressor = @load LinearRegressor pkg=MLJLinearModels
-
-X, y = make_regression(500, 5)
-
-stack = Stack(;metalearner=LinearRegressor(),
-                resampling=CV(),
-                measures=rmse,
-                constant=ConstantRegressor(),
-                tree_2=DecisionTreeRegressor(max_depth=2),
-                tree_3=DecisionTreeRegressor(max_depth=3),
-                evo=EvoTreeRegressor(),
-                knn=KNNRegressor(),
-                xgb=XGBoostRegressor())
-
-mach = machine(stack, X, y)
-evaluate!(mach; resampling=Holdout(), measure=rmse)
-
-```
-
-The internal evaluation report can be accessed like this
-and provides a PerformanceEvaluation object for each model:
-
-```julia
-report(mach).cv_report
-```
-
-"""
 function Stack(
     ;metalearner=nothing,
     resampling=CV(),
@@ -617,3 +518,111 @@ function fit(m::Stack, verbosity::Int, X, y)
 
     return!(mach, m, verbosity, acceleration=m.acceleration)
 end
+
+
+# # DOC STRINGS
+
+const DOC_STACK =
+"""
+    Stack(; metalearner=nothing, name1=model1, name2=model2, ..., keyword_options...)
+
+Implements the two-layer generalized stack algorithm introduced by
+[Wolpert
+(1992)](https://www.sciencedirect.com/science/article/abs/pii/S0893608005800231)
+and generalized by [Van der Laan et al
+(2007)](https://biostats.bepress.com/ucbbiostat/paper222/). Returns an
+instance of type `ProbabilisticStack` or `DeterministicStack`,
+depending on the prediction type of `metalearner`.
+
+When training a machine bound to such an instance:
+
+- The data is split into training/validation sets according to the
+  specified `resampling` strategy.
+
+- Each base model `model1`, `model2`, ... is trained on each training
+  subset and outputs predictions on the corresponding validation
+  sets. The multi-fold predictions are spliced together into a
+  so-called out-of-sample prediction for each model.
+
+- The adjudicating model, `metalearner`, is subsequently trained on
+  the out-of-sample predictions to learn the best combination of base
+  model predictions.
+
+- Each base model is retrained on all supplied data for purposes of
+  passing on new production data onto the adjudicator for making new
+  predictions
+
+### Arguments
+
+- `metalearner::Supervised`: The model that will optimize the desired
+  criterion based on its internals.  For instance, a LinearRegression
+  model will optimize the squared error.
+
+- `resampling`: The resampling strategy used
+  to prepare out-of-sample predictions of the base learners.
+
+- `measures`: A measure or iterable over measures, to perform an internal
+  evaluation of the learners in the Stack while training. This is not for the
+  evaluation of the Stack itself.
+
+- `cache`: Whether machines created in the learning network will cache data or not.
+
+- `acceleration`: A supported `AbstractResource` to define the training parallelization
+  mode of the stack.
+
+- `name1=model1, name2=model2, ...`: the `Supervised` model instances
+  to be used as base learners.  The provided names become properties
+  of the instance created to allow hyper-parameter access
+
+
+### Example
+
+The following code defines a `DeterministicStack` instance for
+learning a `Continuous` target, and demonstrates that:
+
+- Base models can be `Probabilistic` models even if the stack
+  itself is `Deterministic` (`predict_mean` is applied in such cases).
+
+- As an alternative to hyperparameter optimization, one can stack
+  multiple copies of given model, mutating the hyper-parameter used in
+  each copy.
+
+
+```julia
+using MLJ
+
+DecisionTreeRegressor = @load DecisionTreeRegressor pkg=DecisionTree
+EvoTreeRegressor = @load EvoTreeRegressor
+XGBoostRegressor = @load XGBoostRegressor
+KNNRegressor = @load KNNRegressor pkg=NearestNeighborModels
+LinearRegressor = @load LinearRegressor pkg=MLJLinearModels
+
+X, y = make_regression(500, 5)
+
+stack = Stack(;metalearner=LinearRegressor(),
+                resampling=CV(),
+                measures=rmse,
+                constant=ConstantRegressor(),
+                tree_2=DecisionTreeRegressor(max_depth=2),
+                tree_3=DecisionTreeRegressor(max_depth=3),
+                evo=EvoTreeRegressor(),
+                knn=KNNRegressor(),
+                xgb=XGBoostRegressor())
+
+mach = machine(stack, X, y)
+evaluate!(mach; resampling=Holdout(), measure=rmse)
+
+```
+
+The internal evaluation report can be accessed like this
+and provides a PerformanceEvaluation object for each model:
+
+```julia
+report(mach).cv_report
+```
+
+"""
+
+@doc DOC_STACK Stack
+@doc DOC_STACK ProbabilisticStack
+@doc DOC_STACK DeterministicStack

--- a/src/machines.jl
+++ b/src/machines.jl
@@ -119,19 +119,27 @@ function _contains_unknown(F::Type{<:Tuple})
 end
 
 alert_generic_scitype_mismatch(S, F, T) =
-    "The number and/or types of data arguments do not " *
-    "match what the specified model supports. Suppress this "*
-    "type check by specifying `scitype_check_level=0`.\n\n"*
-    "Run `@doc $T` to learn more about your model's requirements.\n"*
-    "Commonly, but non exclusively, supervised models are constructed " *
-    "using the syntax `machine(model, X, y)` or `machine(model, X, y, w)` " *
-    "while most other models are constructed with `machine(model, X)`. " *
-    "Here `X` are features, `y` a target, and `w` sample or class weights.\n\n" *
-    "In general, data in `machine(model, data...)` is expected to satisfy " *
-    "`scitype(data) <: MLJ.fit_data_scitype(model)`.\n"*
-    "In the present case:\n"*
-    "scitype(data) = $S\n"*
-    "fit_data_scitype(model) = $F\n"
+    """
+    The number and/or types of data arguments do not match what the specified model
+    supports. Suppress this type check by specifying `scitype_check_level=0`.
+
+    Run `@doc $(package_name(T)).$(name(T))` to learn more about your model's requirements.
+
+    Commonly, but non exclusively, supervised models are constructed using the syntax
+    `machine(model, X, y)` or `machine(model, X, y, w)` while most other models are
+    constructed with `machine(model, X)`.  Here `X` are features, `y` a target, and `w`
+    sample or class weights.
+
+    In general, data in `machine(model, data...)` is expected to satisfy
+
+        scitype(data) <: MLJ.fit_data_scitype(model)
+
+    In the present case:
+
+    scitype(data) = $S
+
+    fit_data_scitype(model) = $F
+    """
 
 const WARN_UNKNOWN_SCITYPE =
     "Some data contains `Unknown` scitypes, which might lead to model-data mismatches. "


### PR DESCRIPTION
Closes #817

After this PR:

```julia
julia> machine(model, X, y)
┌ Warning: The number and/or types of data arguments do not match what the specified model
│ supports. Suppress this type check by specifying `scitype_check_level=0`.
│ 
│ Run `@doc MLJBase.ProbabilisticStack` to learn more about your model's requirements.
│ 
│ Commonly, but non exclusively, supervised models are constructed using the syntax
│ `machine(model, X, y)` or `machine(model, X, y, w)` while most other models are
│ constructed with `machine(model, X)`.  Here `X` are features, `y` a target, and `w`
│ sample or class weights.
│ 
│ In general, data in `machine(model, data...)` is expected to satisfy
│ 
│     scitype(data) <: MLJ.fit_data_scitype(model)
│ 
│ In the present case:
│ 
│ scitype(data) = Tuple{Table{AbstractVector{Continuous}}, AbstractVector{Continuous}}
│ 
│ fit_data_scitype(model) = Tuple{Table, AbstractVector{<:Finite}}
└ @ MLJBase ~/MLJ/MLJBase/src/machines.jl:176
Machine trained 0 times; caches data
  model: ProbabilisticStack(metalearner = ConstantClassifier(), …)
  args: 
    1:	Source @308 ⏎ `Table{AbstractVector{Continuous}}`
    2:	Source @075 ⏎ `AbstractVector{Continuous}`

```