### PR TITLE
Test suite: modify some uses of `deepcopy`

### DIFF
--- a/test/composition/models/methods.jl
+++ b/test/composition/models/methods.jl
@@ -131,8 +131,8 @@ selector_model = FeatureSelector()
     # to check internals:
     ridge = MLJBase.machines(fitresult.predict)[1]
     selector = MLJBase.machines(fitresult.predict)[2]
-    ridge_old = deepcopy(ridge)
-    selector_old = deepcopy(selector)
+    ridge_old_fitresult = deepcopy(ridge.fitresult)
+    selector_old_fitresult = deepcopy(selector.fitresult)
 
     # this should trigger no retraining:
     fitresult, cache, rep =
@@ -140,8 +140,8 @@ selector_model = FeatureSelector()
             (:info, r"^Not"),
             (:info, r"^Not"),
             MLJBase.update(composite, 2, fitresult, cache, Xtrain, ytrain));
-    @test ridge.fitresult == ridge_old.fitresult
-    @test selector.fitresult == selector_old.fitresult
+    @test ridge.fitresult == ridge_old_fitresult
+    @test selector.fitresult == selector_old_fitresult
 
     # this should trigger update of selector and training of ridge:
     selector_model.features = [:a, :b]
@@ -150,10 +150,10 @@ selector_model = FeatureSelector()
             (:info, r"^Updating"),
             (:info, r"^Training"),
             MLJBase.update(composite, 2, fitresult, cache, Xtrain, ytrain));
-    @test ridge.fitresult != ridge_old.fitresult
-    @test selector.fitresult != selector_old.fitresult
-    ridge_old = deepcopy(ridge)
-    selector_old = deepcopy(selector)
+    @test ridge.fitresult != ridge_old_fitresult
+    @test selector.fitresult != selector_old_fitresult
+    ridge_old_fitresult = deepcopy(ridge.fitresult)
+    selector_old_fitresult = deepcopy(selector.fitresult)
 
     # this should trigger updating of ridge only:
     ridge_model.lambda = 1.0
@@ -162,8 +162,8 @@ selector_model = FeatureSelector()
             (:info, r"^Not"),
             (:info, r"^Updating"),
             MLJBase.update(composite, 2, fitresult, cache, Xtrain, ytrain));
-    @test ridge.fitresult != ridge_old.fitresult
-    @test selector.fitresult == selector_old.fitresult
+    @test ridge.fitresult != ridge_old_fitresult
+    @test selector.fitresult == selector_old_fitresult
 
     predict(composite, fitresult, MLJBase.selectrows(Xin, test));
 


### PR DESCRIPTION
This is necessary to get tests passing on Julia nightly.