### PR TITLE
Fix a bug with `feature_importances(::Machine)`

### DIFF
--- a/src/machines.jl
+++ b/src/machines.jl
@@ -851,7 +851,7 @@ end
 
 function _feature_importances(model, fitresult, report)
     if reports_feature_importances(model)
-        return MMI.feature_importances(mach.model, fitresult, report)
+        return MMI.feature_importances(model, fitresult, report)
     else
         return nothing
     end


### PR DESCRIPTION
Without this PR `feature_importances(mach)` won't work properly unless `reports_feature_importances(mach.model)=false`. Includes new test. 

cc @OkonSamuel 