### PR TITLE
remove unbound type parameters

### DIFF
--- a/src/hyperparam/one_dimensional_range_methods.jl
+++ b/src/hyperparam/one_dimensional_range_methods.jl
@@ -423,11 +423,11 @@ function Distributions.sampler(r::NominalRange{T,N}) where {T, N}
     return sampler(r, fill(1/N, N))
 end
 
-Base.rand(s::NominalSampler, dims::Integer...) where I<:Integer =
+Base.rand(s::NominalSampler, dims::I...) where I<:Integer =
     broadcast(idx -> s.values[idx], rand(s.distribution, dims...))
 Base.rand(rng::AbstractRNG,
           s::NominalSampler,
-          dims::Integer...) where I<:Integer =
+          dims::I...) where I<:Integer =
     broadcast(idx -> s.values[idx], rand(rng, s.distribution, dims...))
 
 

--- a/src/measures/finite.jl
+++ b/src/measures/finite.jl
@@ -25,8 +25,8 @@ $INVARIANT_LABEL
 scitype=DOC_FINITE)
 
 # calling behaviour:
-call(::MCR, ŷ, y) where {V,N} = (y .!= ŷ) |> Mean()
-call(::MCR, ŷ, y, w) where {V,N} = (y .!= ŷ) .* w |> Mean()
+call(::MCR, ŷ, y) = (y .!= ŷ) |> Mean()
+call(::MCR, ŷ, y, w) = (y .!= ŷ) .* w |> Mean()
 (::MCR)(cm::ConfusionMatrixObject) = 1.0 - sum(diag(cm.mat)) / sum(cm.mat)
 
 # -------------------------------------------------------------

--- a/src/resampling.jl
+++ b/src/resampling.jl
@@ -937,7 +937,7 @@ function evaluate!(mach::Machine{<:Measurable};
                    repeats=1,
                    force=false,
                    check_measure=true,
-                   verbosity=1) where M
+                   verbosity=1)
 
     # this method just checks validity of options, preprocess the
     # weights, measures, operations, and dispatches a


### PR DESCRIPTION
Unbound type parameters often cause performance issues and run time dispatch.

Issue found using https://github.com/JuliaLang/julia/pull/46608