### PR TITLE
Relax type restriction on `y` in `train_test_pairs(::StratifiedCV,  rows, y)`

### DIFF
--- a/src/measures/finite.jl
+++ b/src/measures/finite.jl
@@ -530,12 +530,7 @@ for M in (:MulticlassTruePositiveRate, :MulticlassTrueNegativeRate,
             average::T
             return_type::Type{U}
         end
-        # @ablaom says next line looks redundant:
-        $M(average::T, return_type::Type{U}) where {T, U} =
-            $M(average, return_type)
-        $M(; average=macro_avg,
-           return_type=LittleDict) where T<:MulticlassAvg where
-           U<:Union{Vector, LittleDict} = $M(average, return_type)
+        $M(; average=macro_avg, return_type=LittleDict) = $M(average, return_type)
     end
     eval(ex)
 end

--- a/src/measures/probabilistic.jl
+++ b/src/measures/probabilistic.jl
@@ -88,13 +88,12 @@ end
 # Missing values not supported, but allow `Missing` in eltype, because
 # `skipinvalid(yhat, y)` does not tighten the type. See doc string above.
 
-call(::AUC, ŷ::ArrMissing{UnivariateFinite{S,V,R,P}}, y) where {S,V,R,P} =
+call(::AUC, ŷ::ArrMissing{UnivariateFinite{S,V,R,P}}, y) where {S,V,R,P<:Real} =
     _auc(P, ŷ, y)
 
-# corner case of UnivariateFinite's of mixed type
-call(::AUC, ŷ::ArrMissing{UnivariateFinite}, y) where {S,V,R,P} =
-    _auc(Float64, ŷ, y)
-
+# corner case of UnivariateFinite's of mixed type; next line could be removed after
+# resolution of https://github.com/JuliaAI/CategoricalDistributions.jl/issues/37
+call(::AUC, ŷ::ArrMissing{UnivariateFinite}, y) =  _auc(Float64, ŷ, y)
 
 
 # ========================================================

--- a/src/resampling.jl
+++ b/src/resampling.jl
@@ -403,12 +403,6 @@ StratifiedCV(; nfolds::Int=6,  shuffle=nothing, rng=nothing) =
 function train_test_pairs(stratified_cv::StratifiedCV, rows, y)
 
     st = scitype(y)
-    if !(st <: AbstractArray{<:Finite})
-        throw(ArgumentError(
-            "Supplied target has scitype $st but stratified " *
-            "cross-validation applies only to classification problems. "
-        ))
-    end
 
     if stratified_cv.shuffle
         rows=shuffle!(stratified_cv.rng, collect(rows))

--- a/test/_models/Transformers.jl
+++ b/test/_models/Transformers.jl
@@ -132,7 +132,7 @@ end
 # acts on scalars:
 function transform_to_int(
     result::UnivariateDiscretizerResult{<:MLJBase.CategoricalValue},
-    r::Real) where R
+    r::R) where R <: Real
 
     k = R(1)
     for q in result.odd_quantiles

--- a/test/machines.jl
+++ b/test/machines.jl
@@ -227,7 +227,7 @@ end
     mach = @test_logs machine(Scale(2))
     @test mach isa Machine{Scale, false}
     @test report(mach) in [nothing, NamedTuple()]
-    @test isnothing(fitted_params(mach).fitresult)
+    @test isnothing(fitted_params(mach))
     @test_throws(
         MLJBase.ERR_STATIC_ARGUMENTS,
         machine(Scale(2), X),

--- a/test/resampling.jl
+++ b/test/resampling.jl
@@ -443,12 +443,6 @@ end
     pairs_random = MLJBase.train_test_pairs(scv_random, rows, y)
     @test pairs != pairs_random
 
-    # wrong target type throws error:
-    @test_throws(ArgumentError,
-                 MLJBase.train_test_pairs(scv,
-                                          rows,
-                                          CategoricalArrays.unwrap.(y)))
-
     # check class distribution is preserved in a larger randomized example:
     N = 30
     y = shuffle(vcat(fill('a', N), fill('b', 2N),


### PR DESCRIPTION
Resolves #847.

Also fixes some julia 1.8 type parameter warnings. 