### PR TITLE
Re-implement `Stack` as a `NetworkComposite` model

### DIFF
--- a/src/composition/models/stacking.jl
+++ b/src/composition/models/stacking.jl
@@ -42,7 +42,7 @@ mutable struct DeterministicStack{
     modelnames,
     inp_scitype,
     tg_scitype
-} <: DeterministicComposite
+} <: DeterministicNetworkComposite
 
     models::Vector{Supervised}
     metalearner::Deterministic
@@ -78,7 +78,7 @@ mutable struct ProbabilisticStack{
     modelnames,
     inp_scitype,
     tg_scitype
-} <: ProbabilisticComposite
+} <: ProbabilisticNetworkComposite
 
     models::Vector{Supervised}
     metalearner::Probabilistic
@@ -446,7 +446,7 @@ its own training. It also returns the folds_evaluations object if internal cross
 results are requested.
 
 """
-function oos_set(m::Stack, Xs::Source, ys::Source, tt_pairs)
+function oos_set(m::Stack{modelnames}, Xs::Source, ys::Source, tt_pairs) where modelnames
     Zval = []
     yval = []
     folds_evaluations = []
@@ -460,8 +460,9 @@ function oos_set(m::Stack, Xs::Source, ys::Source, tt_pairs)
         # Train each model on the train fold and predict on the validation fold
         # predictions are subsequently used as an input to the metalearner
         Zfold = []
-        for model in getfield(m, :models)
-            mach = machine(model, Xtrain, ytrain, cache=m.cache)
+        for symbolic_model in modelnames
+            model = getproperty(m, symbolic_model)
+            mach = machine(symbolic_model, Xtrain, ytrain, cache=m.cache)
             ypred = predict(mach, Xtest)
             # Internal evaluation on the fold if required
             push!(folds_evaluations, store_for_evaluation(mach, Xtest, ytest, m.measures))
@@ -483,12 +484,10 @@ function oos_set(m::Stack, Xs::Source, ys::Source, tt_pairs)
 end
 
 #######################################
-################# Fit #################
+################# Prefit #################
 #######################################
-"""
-    fit(m::Stack, verbosity::Int, X, y)
-"""
-function fit(m::Stack, verbosity::Int, X, y)
+
+function prefit(m::Stack{modelnames}, verbosity::Int, X, y) where modelnames
     check_stack_measures(m, verbosity, m.measures, y)
     tt_pairs = train_test_pairs(m.resampling, 1:nrows(y), X, y)
 
@@ -497,12 +496,13 @@ function fit(m::Stack, verbosity::Int, X, y)
 
     Zval, yval, folds_evaluations = oos_set(m, Xs, ys, tt_pairs)
 
-    metamach = machine(m.metalearner, Zval, yval, cache=m.cache)
+    metamach = machine(:metalearner, Zval, yval, cache=m.cache)
 
     # Each model is retrained on the original full training set
     Zpred = []
-    for model in getfield(m, :models)
-        mach = machine(model, Xs, ys, cache=m.cache)
+    for symbolic_model in modelnames
+        model = getproperty(m, symbolic_model)
+        mach = machine(symbolic_model, Xs, ys, cache=m.cache)
         ypred = predict(mach, Xs)
         ypred = pre_judge_transform(ypred, typeof(model), target_scitype(model))
         push!(Zpred, ypred)
@@ -513,10 +513,13 @@ function fit(m::Stack, verbosity::Int, X, y)
 
     internal_report = internal_stack_report(m, verbosity, tt_pairs, folds_evaluations...)
 
-    # We can infer the Surrogate by two calls to supertype
-    mach = machine(supertype(supertype(typeof(m)))(), Xs, ys; predict=ŷ, internal_report...)
+    # return learning network interface:
+    (;
+     predict = ŷ,
+     acceleration=m.acceleration,
+     internal_report..., # `internal_report` has form `(; report=(; cv_report=some_node))`
+     )
 
-    return!(mach, m, verbosity, acceleration=m.acceleration)
 end
 
 

--- a/test/composition/learning_networks/machines.jl
+++ b/test/composition/learning_networks/machines.jl
@@ -172,15 +172,17 @@ end
     smach = MLJBase.serializable(mach)
     TestUtilities.generic_tests(mach, smach)
     # Check data has been wiped out from models at the first level of composition
-    @test length(machines(glb(smach))) == length(machines(glb(mach)))
-    for submach in machines(glb(smach))
+    submachines = machines(glb(mach.fitresult))
+    ssubmachines = machines(glb(smach.fitresult))
+    @test length(submachines) == length(ssubmachines)
+    for submach in ssubmachines
         TestUtilities.test_data(submach)
     end
 
     # Testing extra report field : it is a deepcopy
     @test report(smach).cv_report === report(mach).cv_report
 
-    @test smach.fitresult isa MLJBase.CompositeFitresult
+    @test smach.fitresult isa MLJBase.Signature
 
     Serialization.serialize(filename, smach)
     smach = Serialization.deserialize(filename)
@@ -217,10 +219,10 @@ end
     @test predict(smach, X) == predict(mach, X)
 
     # Test data as been erased at the first and second level of composition
-    for submach in machines(glb(smach))
+    for submach in machines(glb(smach.fitresult))
         TestUtilities.test_data(submach)
         if submach isa Machine{<:Composite}
-            for subsubmach in machines(glb(submach))
+            for subsubmach in machines(glb(submach.fitresult))
                 TestUtilities.test_data(subsubmach)
             end
         end

--- a/test/composition/models/stacking.jl
+++ b/test/composition/models/stacking.jl
@@ -44,75 +44,84 @@ end
     X, y = make_regression(500, 5; rng=rng)
 
     @testset "Testing Deterministic Stack" begin
-    # Testing performance
+        # Testing performance
 
-    # The dataset is a simple regression model with intercept
-    # No model in the stack can recover the true model on its own
-    # Indeed, FooBarRegressor has no intercept
-    # By combining models, the stack can generalize better than any submodel
-    # And optimize the rmse
+        # The dataset is a simple regression model with intercept
+        # No model in the stack can recover the true model on its own
+        # Indeed, FooBarRegressor has no intercept
+        # By combining models, the stack can generalize better than any submodel
+        # And optimize the rmse
 
-    models = (constant=DeterministicConstantRegressor(),
-                decisiontree=DecisionTreeRegressor(),
-                ridge_lambda=FooBarRegressor(;lambda=0.1),
-                ridge=FooBarRegressor(;lambda=0))
+        models = (constant=DeterministicConstantRegressor(),
+                  decisiontree=DecisionTreeRegressor(),
+                  ridge_lambda=FooBarRegressor(;lambda=0.1),
+                  ridge=FooBarRegressor(;lambda=0))
 
-    mystack = Stack(;metalearner=FooBarRegressor(),
-                    resampling=CV(;nfolds=3),
-                    models...)
+        mystack = Stack(;metalearner=FooBarRegressor(),
+                        resampling=CV(;nfolds=3),
+                        models...)
 
-    results = model_evaluation((stack=mystack, models...), X, y)
-    @test argmin(results) == 1
+        results = model_evaluation((stack=mystack, models...), X, y)
+        @test argmin(results) == 1
 
-    # Mixing ProbabilisticModels amd Deterministic models as members of the stack
-    models = (constant=ConstantRegressor(),
-                decisiontree=DecisionTreeRegressor(),
-                ridge_lambda=FooBarRegressor(;lambda=0.1),
-                ridge=FooBarRegressor(;lambda=0))
+        # Mixing ProbabilisticModels amd Deterministic models as members of the stack
+        models = (constant=ConstantRegressor(),
+                  decisiontree=DecisionTreeRegressor(),
+                  ridge_lambda=FooBarRegressor(;lambda=0.1),
+                  ridge=FooBarRegressor(;lambda=0))
 
-    mystack = Stack(;metalearner=FooBarRegressor(),
-                    resampling=CV(;nfolds=3),
-                    models...)
-    # Testing attribute access of the stack
-    @test propertynames(mystack) == (:metalearner, :resampling, :measures, :cache, :acceleration, 
-        :constant, :decisiontree, :ridge_lambda, :ridge)
+        mystack = Stack(;metalearner=FooBarRegressor(),
+                        resampling=CV(;nfolds=3),
+                        models...)
+        # Testing attribute access of the stack
+        @test propertynames(mystack) == (
+            :metalearner,
+            :resampling,
+            :measures,
+            :cache,
+            :acceleration,
+            :constant,
+            :decisiontree,
+            :ridge_lambda,
+            :ridge,
+        )
 
-    @test mystack.decisiontree isa DecisionTreeRegressor
+        @test mystack.decisiontree isa DecisionTreeRegressor
 
-    @test target_scitype(mystack) == target_scitype(FooBarRegressor())
-    @test input_scitype(mystack) == input_scitype(FooBarRegressor())
+        @test target_scitype(mystack) == target_scitype(FooBarRegressor())
+        @test input_scitype(mystack) == input_scitype(FooBarRegressor())
 
-    # Testing fitted_params results are easily accessible for each
-    # submodel. They are in order of the cross validation procedure.
-    # Here 3-folds then 3 machines + the final fit
-    mach = machine(mystack, X, y)
-    fit!(mach, verbosity=0)
-    fp = fitted_params(mach)
-    @test nrows(getfield(fp, :constant)) == 4
-    @test nrows(getfield(fp, :decisiontree)) == 4
-    @test nrows(getfield(fp, :ridge)) == 4
-    @test nrows(getfield(fp, :ridge_lambda)) == 4
+        # Testing fitted_params results are easily accessible for each
+        # submodel. They are in order of the cross validation procedure.
+        # Here 3-folds then 3 machines + the final fit
+        mach = machine(mystack, X, y)
+        fit!(mach, verbosity=0)
+        fp = fitted_params(mach)
+        @test nrows(getfield(fp, :constant)) == 4
+        @test nrows(getfield(fp, :decisiontree)) == 4
+        @test nrows(getfield(fp, :ridge)) == 4
+        @test nrows(getfield(fp, :ridge_lambda)) == 4
 
-    # The metalearner has been fit and has one coefficient
-    # for each model in the library (No intercept)
-    @test fp.metalearner isa Vector{Float64}
-    @test nrows(fp.metalearner) == 4
+        # The metalearner has been fit and has one coefficient
+        # for each model in the library (No intercept)
+        @test fp.metalearner isa Vector{Float64}
+        @test nrows(fp.metalearner) == 4
 
-    # Testing prediction is Deterministic
-    @test predict(mach) isa Vector{Float64}
+        # Testing prediction is Deterministic
+        @test predict(mach) isa Vector{Float64}
     end
 
     @testset "Testing ProbabilisticStack" begin
         models = (constant=ConstantRegressor(),
-                    decisiontree=DecisionTreeRegressor(),
-                    ridge_lambda=FooBarRegressor(;lambda=0.1),
-                    ridge=FooBarRegressor(;lambda=0))
+                  decisiontree=DecisionTreeRegressor(),
+                  ridge_lambda=FooBarRegressor(;lambda=0.1),
+                  ridge=FooBarRegressor(;lambda=0))
 
         # The type of the stack is determined by the type of the metalearner
         metalearner = ConstantRegressor(;distribution_type=Distributions.Cauchy)
         mystack = Stack(;metalearner=metalearner,
-                    resampling=CV(;nfolds=3),
-                    models...)
+                        resampling=CV(;nfolds=3),
+                        models...)
 
         @test target_scitype(mystack) == target_scitype(metalearner)
         @test input_scitype(mystack) == input_scitype(FooBarRegressor())
@@ -211,7 +220,14 @@ end
     cache = true
     acceleration = CPU1()
 
-    MLJBase.DeterministicStack(modelnames, models, metalearner, resampling, nothing, cache, acceleration)
+    @test_logs MLJBase.DeterministicStack(
+        modelnames,
+        models,
+        metalearner,
+        resampling,
+        nothing,
+        cache,
+        acceleration)
 
     # Test input_target_scitypes with non matching target_scitypes
     models = [KNNRegressor()]
@@ -284,7 +300,7 @@ end
     @test all(x === nothing for x in folds_evaluations)
 
     # To be accessed, the machines need to be trained
-    fit!(Zval, verbosity=0)
+    fit!(Zval, verbosity=0, composite=stack)
     # Each model in the library should output a 3-dim vector to be concatenated
     # resulting in the table of shape (nrows, 6) here nrows=6
     # for future use by the metalearner
@@ -389,7 +405,6 @@ end
     @test yhat_matrix_stack ≈ yhat_matrix
 
 end
-
 
 @testset "Test store_for_evaluation" begin
     X, y = make_blobs(;rng=rng, shuffle=false)
@@ -559,7 +574,7 @@ end
     mach = machine(mystack, X, y)
     fit!(mach, verbosity = 0)
     # The data and resampled_data have not been populated
-    for mach in fitted_params(mach).machines
+    for mach in machines(glb(mach.fitresult))
         @test !isdefined(mach, :data)
         @test !isdefined(mach, :resampled_data)
     end


### PR DESCRIPTION
Currently `Stack` is implemented as a `Composite` model, an abstract type to be deprecated in favour of `NetworkComposite` added by #841.

This is mildly breaking, as indicated in #852.