### PR TITLE
For a 0.21.2 release

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MLJBase"
 uuid = "a7f614a8-145f-11e9-1d2a-a57a1082229d"
 authors = ["Anthony D. Blaom <anthony.blaom@gmail.com>"]
-version = "0.21.1"
+version = "0.21.2"
 
 [deps]
 CategoricalArrays = "324d7699-5711-5eae-9e2f-1d82baa6b597"

--- a/src/composition/models/deprecated_from_network.jl
+++ b/src/composition/models/deprecated_from_network.jl
@@ -265,7 +265,7 @@ macro nodepwarn_from_network(exs...)
     from_network_(__module__, args...)
 end
 macro from_network(exs...)
-    MLJBase.depwarn(WARN_FROM_NETWORK_DEPRECATION, :from_network, force=true)
+    Base.depwarn(WARN_FROM_NETWORK_DEPRECATION, :from_network, force=true)
     args = from_network_preprocess(__module__, exs...)
     modeltype_ex = args[2]
     from_network_(__module__, args...)


### PR DESCRIPTION
Fix bug: `MLJBase.depwarn` should have been `Base.depwarn` in redefinition of deprecated `@from_network`. To address fail at https://github.com/OutlierDetectionJL/OutlierDetection.jl/pull/36