### PR TITLE
Add check for base models in `Stack`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,7 @@ jobs:
           - '1' # automatically expands to the latest stable 1.x release of Julia.
         os:
           - ubuntu-latest
+          - macOS-latest
         arch:
           - x64
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,6 @@ jobs:
           - '1' # automatically expands to the latest stable 1.x release of Julia.
         os:
           - ubuntu-latest
-          - macOS-latest
         arch:
           - x64
     steps:

--- a/src/composition/models/stacking.jl
+++ b/src/composition/models/stacking.jl
@@ -46,7 +46,7 @@ const ERR_NO_METALEARNER = ArgumentError(
     "No metalearner specified. Use Stack(metalearner=..., model1=..., model2=...)"
 )
 
-# checks `model` is either a probabilistic classifier or a deterministic regressor:
+# checks `model` is either a probabilistic classifier or a regressor:
 function check_valid_basemodel(model)
     okay =
         (prediction_type(model) == :probabilistic &&

--- a/src/composition/models/stacking.jl
+++ b/src/composition/models/stacking.jl
@@ -35,7 +35,9 @@ const ERR_BAD_METALEARNER = ArgumentError(
 )
 
 ERR_BAD_BASEMODEL(model) = ArgumentError(
-    "The base model $model is not supported. The model must either be a "*
+    "The base model $model is not supported as it appears to "*
+    "be a classifier predicting point values. Ordinarily, the "*
+    "the model must either be a "*
     "probabilistic classifier (output of `predict` is a vector of  "*
     "`UnivariateFinite`) "*
     "or a regressor (`target_scitype(model) <: "*
@@ -48,11 +50,9 @@ const ERR_NO_METALEARNER = ArgumentError(
 
 # checks `model` is either a probabilistic classifier or a regressor:
 function check_valid_basemodel(model)
-    okay =
-        (prediction_type(model) == :probabilistic &&
-        target_scitype(model) <: AbstractVector{<:Union{Finite,Missing}}) ||
-        (target_scitype(model) <: AbstractVector{<:Union{Continuous,Missing}})
-    okay || throw(ERR_BAD_BASEMODEL(model))
+    problem = prediction_type(model) === :deterministic &&
+        target_scitype(model) <: AbstractVector{<:Union{Finite,Missing}}
+    problem && throw(ERR_BAD_BASEMODEL(model))
     return nothing
 end
 

--- a/test/composition/models/stacking.jl
+++ b/test/composition/models/stacking.jl
@@ -158,6 +158,13 @@ end
 end
 
 @testset "Stack constructor valid argument checks" begin
+
+    # baselearner cannot be a deterministic classifier:
+    @test_throws(
+    MLJBase.ERR_BAD_BASEMODEL(DeterministicConstantClassifier()),
+    Stack(metalearner=ConstantClassifier(), mymodel=DeterministicConstantClassifier()),
+    )
+
     # metalearner should be `Deterministic` or `Probablisitic`:
     @test_throws(
         MLJBase.ERR_BAD_METALEARNER,


### PR DESCRIPTION
Closes #861

Adds a check on the base models in a `Stack` when `clean!` is called. As far as I can tell, I'm only ruling out models here that would lead to unexpected behaviour or confusing error messages. 
