### PR TITLE
fix bug in auc computation

### DIFF
--- a/src/measures/roc.jl
+++ b/src/measures/roc.jl
@@ -43,6 +43,12 @@ To draw the curve using your favorite plotting backend, do `plot(fprs, tprs)`.
 """
 function roc_curve(ŷm, ym)
     ŷ, y    = skipinvalid(ŷm, ym)
+    length(classes(ŷ)) ==  2 || throw(
+        ArgumentError("`ŷ` must be a two-class probabilistic prediction")
+    )
+    length(levels(y)) == 2 || throw(
+        ArgumentError("`y` must be a categorical vector with two-levels.")
+    )
     n       = length(y)
     lab_pos = levels(y)[2]
     scores  = pdf.(ŷ, lab_pos)

--- a/test/measures/probabilistic.jl
+++ b/test/measures/probabilistic.jl
@@ -54,7 +54,7 @@ const Vec = AbstractVector
     # The auc algorithm should be able to handle the case where two or more
     # samples in the prediction vector has the same UnivariateFinite distribution
     # We check this by comparing our auc with that gotten from roc_auc_score from sklearn.
-    y = categorical(["class_1","class_1","class_1","class_0","class_1","class_1","class_0"])
+    y = categorical(["class_1","class_1","class_0","class_0","class_1","class_1","class_0"])
     ŷ = UnivariateFinite(levels(y), [0.8,0.7,0.5,0.5,0.5,0.5,0.3], augment=true, pool=y)
     # We can see that ŷ[3] ≈ ŷ[4] ≈ ŷ[5] ≈ ŷ[6]
     @test isapprox(auc(ŷ, y), 0.8333333333333334, rtol=1e-16)

--- a/test/measures/probabilistic.jl
+++ b/test/measures/probabilistic.jl
@@ -51,6 +51,13 @@ const Vec = AbstractVector
     ŷ2 = UnivariateFinite(y2[1:2], probs, augment=true) # same probs
     @test isapprox(auc(ŷ2, y2), auc(ŷ, y), rtol=1e-4)
 
+    # The auc algorithm should be able to handle the case where two or more
+    # samples in the prediction vector has the same UnivariateFinite distribution
+    # We check this by comparing our auc with that gotten from roc_auc_score from sklearn.
+    y = categorical(["class_1","class_1","class_1","class_0","class_1","class_1","class_0"])
+    ŷ = UnivariateFinite(levels(y), [0.8,0.7,0.5,0.5,0.5,0.5,0.3], augment=true, pool=y)
+    # We can see that ŷ[3] ≈ ŷ[4] ≈ ŷ[5] ≈ ŷ[6]
+    @test isapprox(auc(ŷ, y), 0.8333333333333334, rtol=1e-16)
 end
 
 @testset "Log, Brier, Spherical - finite case" begin


### PR DESCRIPTION
This PR fixes a bug in the existing auc computation. The existing implementation gave incorrect auc prediction compared to other packages (e.g sklearn) in the case where two or more samples in the prediction vector has the same `UnivariateFinite` distributions.

## Before this PR
```julia
julia> y = categorical(["class_1","class_1","class_0","class_0","class_1","class_1","class_0"])
7-element CategoricalArrays.CategoricalArray{String,1,UInt32}:
 "class_1"
 "class_1"
 "class_0"
 "class_0"
 "class_1"
 "class_1"
 "class_0"

julia> ŷ = UnivariateFinite(levels(y), [0.8,0.7,0.5,0.5,0.5,0.5,0.3], augment=true, pool=y)
7-element UnivariateFiniteVector{Multiclass{2}, String, UInt32, Float64}:
 UnivariateFinite{Multiclass{2}}(class_0=>0.2, class_1=>0.8)
 UnivariateFinite{Multiclass{2}}(class_0=>0.3, class_1=>0.7)
 UnivariateFinite{Multiclass{2}}(class_0=>0.5, class_1=>0.5)
 UnivariateFinite{Multiclass{2}}(class_0=>0.5, class_1=>0.5)
 UnivariateFinite{Multiclass{2}}(class_0=>0.5, class_1=>0.5)
 UnivariateFinite{Multiclass{2}}(class_0=>0.5, class_1=>0.5)
 UnivariateFinite{Multiclass{2}}(class_0=>0.7, class_1=>0.3)

julia> auc(ŷ, y)
1.0
```

## After this PR
```julia
julia> y = categorical(["class_1","class_1","class_0","class_0","class_1","class_1","class_0"])
7-element CategoricalArrays.CategoricalArray{String,1,UInt32}:
 "class_1"
 "class_1"
 "class_0"
 "class_0"
 "class_1"
 "class_1"
 "class_0"

julia> ŷ = UnivariateFinite(levels(y), [0.8,0.7,0.5,0.5,0.5,0.5,0.3], augment=true, pool=y)
7-element UnivariateFiniteVector{Multiclass{2}, String, UInt32, Float64}:
 UnivariateFinite{Multiclass{2}}(class_0=>0.2, class_1=>0.8)
 UnivariateFinite{Multiclass{2}}(class_0=>0.3, class_1=>0.7)
 UnivariateFinite{Multiclass{2}}(class_0=>0.5, class_1=>0.5)
 UnivariateFinite{Multiclass{2}}(class_0=>0.5, class_1=>0.5)
 UnivariateFinite{Multiclass{2}}(class_0=>0.5, class_1=>0.5)
 UnivariateFinite{Multiclass{2}}(class_0=>0.5, class_1=>0.5)
 UnivariateFinite{Multiclass{2}}(class_0=>0.7, class_1=>0.3)

julia> auc(ŷ, y)
0.8333333333333334 #sames as sklearn
```