### PR TITLE
Fix `evaluate` display incompatiblity with Term.jl

### DIFF
--- a/src/resampling.jl
+++ b/src/resampling.jl
@@ -547,8 +547,12 @@ function _standard_errors(e::PerformanceEvaluation)
     return std_errors
 end
 
+# to address #874, while preserving the display worked out in #757:
+_repr_(f::Function) = repr(f)
+_repr_(x) = repr("text/plain", x)
+
 function Base.show(io::IO, ::MIME"text/plain", e::PerformanceEvaluation)
-    _measure = [repr(MIME("text/plain"), m) for m in e.measure]
+    _measure = [_repr_(m) for m in e.measure]
     _measurement = round3.(e.measurement)
     _per_fold = [round3.(v) for v in e.per_fold]
     _sterr = round3.(_standard_errors(e))


### PR DESCRIPTION
 Closes #874.

```julia
custom_measure(x, y) = accuracy(x, y)
measures = [custom_measure, log_loss,  MulticlassPrecision()]
X, y = make_blobs()
y = coerce(y, OrderedFactor)

julia> evaluate(
       ConstantClassifier(),
       X,
       y;
       measures,
       )
PerformanceEvaluation object with these fields:
  measure, operation, measurement, per_fold,
  per_observation, fitted_params_per_fold,
  report_per_fold, train_test_rows
Extract:
┌──────────────────────────────────┬──────────────┬─────────────┬─────────┬──────────────────────────────────────────┐
│ measure                          │ operation    │ measurement │ 1.96*SE │ per_fold                                 │
├──────────────────────────────────┼──────────────┼─────────────┼─────────┼──────────────────────────────────────────┤
│ custom_measure                   │ predict      │ 0.0         │ N/A     │ [0.0, 0.0, 0.0, 0.0, 0.0, 0.0]           │
│ LogLoss(                         │ predict      │ 1.12        │ 0.0244  │ [1.1, 1.15, 1.1, 1.17, 1.11, 1.11]       │
│   tol = 2.220446049250313e-16)   │              │             │         │                                          │
│ MulticlassPrecision(             │ predict_mode │ 0.23        │ N/A     │ [0.294, 0.176, 0.294, 0.118, 0.25, 0.25] │
│   average = MLJBase.MacroAvg(),  │              │             │         │                                          │
│   return_type = LittleDict)      │              │             │         │                                          │
└──────────────────────────────────┴──────────────┴─────────────┴─────────┴──────────────────────────────────────────┘
```

with the same display after `using Term; install_term_repr()`.