### PR TITLE
Preparing MLJBase to receive logger instances

### DIFF
--- a/src/composition/models/stacking.jl
+++ b/src/composition/models/stacking.jl
@@ -396,7 +396,9 @@ function internal_stack_report(
             per_observation = Vector{Union{Missing, Vector{Any}}}(missing, n_measures),
             fitted_params_per_fold = [],
             report_per_fold = [],
-            train_test_pairs = tt_pairs
+            train_test_pairs = tt_pairs,
+            resampling = stack.resampling,
+            repeats = 1
         )
          for model in getfield(stack, :models)
          ]

--- a/src/composition/models/stacking.jl
+++ b/src/composition/models/stacking.jl
@@ -388,6 +388,7 @@ function internal_stack_report(
     # For each model we record the results mimicking the fields PerformanceEvaluation
     results = NamedTuple{modelnames}(
         [(
+            model = model,
             measure = stack.measures,
             measurement = Vector{Any}(undef, n_measures),
             operation = _actual_operations(nothing, stack.measures, model, verbosity),


### PR DESCRIPTION
This PR contains the changes related to functions that can be extended by any logger projects (in this case, mlflow). It contains:

- A `log_evaluation` function that receives a logger instance and a performance evaluation.  It can be extended by any project that logs to a platform.
- Adapting MLJBase functions that receive logger as argument.

This changes can be seen applied in [MLJFlow.jl](https://github.com/JuliaAI/MLJFlow.jl).

Useful links:
- alan-turing-institute/MLJ.jl#1029
- Old PR: #912 