### PR TITLE
Remove `target` as alias for `transformer` in `TransformedTargetModel`

### DIFF
--- a/src/composition/models/pipelines.jl
+++ b/src/composition/models/pipelines.jl
@@ -138,13 +138,7 @@ const ERR_MIXED_PIPELINE_SPEC = ArgumentError(
     "Either specify all pipeline components without names, as in "*
     "`Pipeline(model1, model2)` or specify names for all "*
     "components, as in `Pipeline(myfirstmodel=model1, mysecondmodel=model2)`. ")
-const ERR_USING_TARGET_KWARG = ArgumentError(
-    "You are not permitted to name a pipeline component \"target\", "*
-    "as this may be confused with the `target` keyword argument for "*
-    "the older `@pipeline` macro. `Pipeline` does not support target "*
-    "transformations. To implement one, wrap a supervised "*
-    "`model` using `TransformedTargetModel`, as in "*
-    "`TransformedTargetModel(model, transformer=Standardizer())`. ")
+
 
 # The following combines its arguments into a named tuple, performing
 # a number of checks and modifications. Specifically, it checks
@@ -277,7 +271,6 @@ function Pipeline(args...; prediction_type=nothing,
     # construct the named tuple of components:
     if isempty(args)
         _names = keys(kwargs)
-        :target in _names && throw(ERR_USING_TARGET_KWARG)
         _components = values(values(kwargs))
     else
         _names = Symbol[]

--- a/src/composition/models/transformed_target_model.jl
+++ b/src/composition/models/transformed_target_model.jl
@@ -140,8 +140,7 @@ tmodel2 = TransformedTargetModel(model, transformer=y->log.(y), inverse=z->exp.(
 function TransformedTargetModel(
     args...;
     model=nothing,
-    target=nothing,    # to be deprecated
-    transformer=target,  # then this should be `nothing`
+    transformer=nothing,
     inverse=nothing,
     cache=true,
 )

--- a/src/composition/models/transformed_target_model.jl
+++ b/src/composition/models/transformed_target_model.jl
@@ -145,8 +145,6 @@ function TransformedTargetModel(
     cache=true,
 )
 
-    isnothing(target) ||
-        Base.depwarn(WARN_TARGET_DEPRECATED, :TransformedTargetModel, force=true)
     length(args) < 2 || throw(ERR_TOO_MANY_ARGUMENTS)
 
     if length(args) === 1

--- a/test/composition/models/pipelines.jl
+++ b/test/composition/models/pipelines.jl
@@ -113,7 +113,6 @@ end
     @test_logs @test Pipeline(m, t, u, d, u) isa DeterministicPipeline
 
     # named components:
-    @test_throws MLJBase.ERR_USING_TARGET_KWARG Pipeline(target=u)
     @test Pipeline(c1=m, c2=t, c3=u) isa UnsupervisedPipeline
     @test Pipeline(c1=m, c2=t, c3=u, c5=p) isa ProbabilisticPipeline
     @test Pipeline(c1=m, c2=t) isa StaticPipeline

--- a/test/composition/models/transformed_target_model.jl
+++ b/test/composition/models/transformed_target_model.jl
@@ -18,10 +18,6 @@ whitener = UnivariateStandardizer()
         TransformedTargetModel(atom),
     )
     @test_logs TransformedTargetModel(atom, transformer=UnivariateStandardizer)
-    model = @test_logs(
-        (:warn, MLJBase.WARN_TARGET_DEPRECATED),
-        TransformedTargetModel(atom, target=whitener),
-    )
     model = @test_logs TransformedTargetModel(atom, transformer=whitener)
     @test model.model == atom
     @test model.inverse == nothing


### PR DESCRIPTION
Closes #856.

For release notes:

- (**breaking**) Disallow `target` keyword argument in `TransformedTargetModel(...)`. Use `transformer=...` instead`. (#856)