### PR TITLE
Rescue the orphaned docstring for `evaluate` 

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MLJBase"
 uuid = "a7f614a8-145f-11e9-1d2a-a57a1082229d"
 authors = ["Anthony D. Blaom <anthony.blaom@gmail.com>"]
-version = "1.0.0"
+version = "1.0.1"
 
 [deps]
 CategoricalArrays = "324d7699-5711-5eae-9e2f-1d82baa6b597"

--- a/src/resampling.jl
+++ b/src/resampling.jl
@@ -940,7 +940,6 @@ Although `evaluate!` is mutating, `mach.model` and `mach.args` are not mutated.
 See also [`evaluate`](@ref), [`PerformanceEvaluation`](@ref)
 
 """
-
 function evaluate!(
     mach::Machine{<:Measurable};
     resampling=CV(),


### PR DESCRIPTION
- rescue orphaned docstring for evaluate!
- bump 1.0.1
