### PR TITLE
Fix Resampler update bug

### DIFF
--- a/src/resampling.jl
+++ b/src/resampling.jl
@@ -1591,8 +1591,15 @@ function MLJModelInterface.update(
     mach, e = fitresult
     train_test_rows = e.train_test_rows
 
-    measures = e.measure
-    operations = e.operation
+    # since `resampler.model` could have changed, so might the actual measures and
+    # operations that should be passed to the (low level) `evaluate!`:
+    measures = _actual_measures(resampler.measure, resampler.model)
+    operations = _actual_operations(
+        resampler.operation,
+        measures,
+        resampler.model,
+        verbosity
+    )
 
     # update the model:
     mach2 = _update!(mach, resampler.model)

--- a/test/resampling.jl
+++ b/test/resampling.jl
@@ -1,5 +1,3 @@
-#module TestResampling
-
 using Distributed
 import ComputationalResources: CPU1, CPUProcesses, CPUThreads
 using .TestUtilities
@@ -876,5 +874,21 @@ end
     @test contains(printed_evaluations, "N/A")
 end
 
-#end
+@testset_accelerated "issue with Resampler #954" acceleration begin
+    knn = KNNClassifier()
+    cnst =DeterministicConstantClassifier()
+    X, y = make_blobs(10)
+
+    resampler = MLJBase.Resampler(
+        ;model=knn,
+        measure=accuracy,
+        operation=nothing,
+        acceleration,
+    )
+    mach = machine(resampler, X, y) |> fit!
+
+    resampler.model = cnst
+    fit!(mach)
+end
+
 true


### PR DESCRIPTION
This PR fixes a problem when the model wrapped by a `Resampler` instance is mutated to one of different prediction type. I ran into this while working on https://github.com/JuliaAI/MLJTuning.jl/pull/201.

```julia
using MLJBase, MLJModels
KNNClassifier = @load KNNClassifier

knn = KNNClassifier()
cnst =DeterministicConstantClassifier()

X, y = make_blobs()

resampler = MLJBase.Resampler(model=knn, measure=accuracy, operation=nothing)
mach = machine(resampler, X, y) |> fit!

resampler.model = cnst
fit!(mach)
# [ Info: Updating machine(Resampler(model = DeterministicConstantClassifier(), …), …).
# ERROR: MethodError: no method matching iterate(::CategoricalArrays.CategoricalValue{Int64, UInt32})

# Closest candidates are:
#   iterate(::LibGit2.GitBranchIter)
#    @ LibGit2 /Applications/Julia-1.10.app/Contents/Resources/julia/share/julia/stdlib/v1.10/LibGit2/src/reference.jl:343
#   iterate(::LibGit2.GitBranchIter, ::Any)
#    @ LibGit2 /Applications/Julia-1.10.app/Contents/Resources/julia/share/julia/stdlib/v1.10/LibGit2/src/reference.jl:343
#   iterate(::Parameters.Lines)
#    @ Parameters ~/.julia/packages/Parameters/MK0O4/src/Parameters.jl:78
#   ...

# Stacktrace:
#   [1] isempty(itr::CategoricalArrays.CategoricalValue{Int64, UInt32})
#     @ Base ./essentials.jl:952
#   [2] mode(a::CategoricalArrays.CategoricalValue{Int64, UInt32})
#     @ StatsBase ~/.julia/packages/StatsBase/WLz8A/src/scalarstats.jl:112
#   [3] _broadcast_getindex_evalf
#     @ ./broadcast.jl:709 [inlined]
#   [4] _broadcast_getindex
#     @ ./broadcast.jl:682 [inlined]
#   [5] getindex
#     @ ./broadcast.jl:636 [inlined]
#   [6] copy
#     @ ./broadcast.jl:942 [inlined]
#   [7] materialize
#     @ ./broadcast.jl:903 [inlined]
#   [8] predict_mode(m::DeterministicConstantClassifier, fitresult::CategoricalArrays.CategoricalValue{…}, Xnew::@NamedTuple{…})                                
#     @ MLJBase ~/MLJ/MLJBase/src/interface/model_api.jl:11
#   [9] predict_mode(mach::Machine{DeterministicConstantClassifier, true}; rows::UnitRange{Int64})                                                                                    
#     @ MLJBase ~/MLJ/MLJBase/src/operations.jl:86
#  [10] predict_mode
#     @ ~/MLJ/MLJBase/src/operations.jl:82 [inlined]
```