### PR TITLE
Reduce sigdigits in parameter range display #948

### DIFF
--- a/src/hyperparam/one_dimensional_ranges.jl
+++ b/src/hyperparam/one_dimensional_ranges.jl
@@ -32,7 +32,7 @@ end
 # throws an exception:
 function _repr(r::NumericRange{T}, field) where T
     value = getproperty(r, field)
-    if !(typeof(value) <: Integer)
+    if !(value isa Integer)
         value = round(value, sigdigits=4)
     end
     r.scale isa Symbol && return repr(value)

--- a/src/hyperparam/one_dimensional_ranges.jl
+++ b/src/hyperparam/one_dimensional_ranges.jl
@@ -31,7 +31,7 @@ end
 # case that `r.scale` is not a symbol, and returning "?" if applying the transformation
 # throws an exception:
 function _repr(r::NumericRange{T}, field) where T
-    value = getproperty(r, field)
+    value = round(getproperty(r, field), sigdigits=4)
     r.scale isa Symbol && return repr(value)
     return try
         scaled = (r.scale)(value)

--- a/src/hyperparam/one_dimensional_ranges.jl
+++ b/src/hyperparam/one_dimensional_ranges.jl
@@ -31,7 +31,10 @@ end
 # case that `r.scale` is not a symbol, and returning "?" if applying the transformation
 # throws an exception:
 function _repr(r::NumericRange{T}, field) where T
-    value = round(getproperty(r, field), sigdigits=4)
+    value = getproperty(r, field)
+    if !(typeof(value) <: Integer)
+        value = round(value, sigdigits=4)
+    end
     r.scale isa Symbol && return repr(value)
     return try
         scaled = (r.scale)(value)

--- a/test/hyperparam/one_dimensional_ranges.jl
+++ b/test/hyperparam/one_dimensional_ranges.jl
@@ -120,10 +120,13 @@ end
     io = IOBuffer()
     r1 = range(Int, :junk, lower=1, upper=10)
     r2 = range(Char, :junk, values=['c', 'd'])
+    r3 = range(Float64, :junk, lower=3.14159, upper=6.283185)
     show(io, r1)
     @test String(take!(io)) == "NumericRange(1 ≤ junk ≤ 10; origin=5.5, unit=4.5)"
     show(io, r2)
     @test String(take!(io)) == "NominalRange(junk = c, d)"
+    show(io, r3)
+    @test String(take!(io)) == "NumericRange(3.142 ≤ junk ≤ 6.283; origin=4.712, unit=1.571)"
     close(io)
 end
 


### PR DESCRIPTION
This commit addresses issue #948 by updating the display of parameter ranges to include reduced significant digits.