### PR TITLE
Fix some error message diagnostics

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MLJBase"
 uuid = "a7f614a8-145f-11e9-1d2a-a57a1082229d"
 authors = ["Anthony D. Blaom <anthony.blaom@gmail.com>"]
-version = "1.1.2"
+version = "1.1.3"
 
 [deps]
 CategoricalArrays = "324d7699-5711-5eae-9e2f-1d82baa6b597"

--- a/src/composition/learning_networks/nodes.jl
+++ b/src/composition/learning_networks/nodes.jl
@@ -150,17 +150,18 @@ function _apply(y_plus, input...; kwargs...)
     try
         (y.operation)(mach..., raw_args...)
     catch exception
+        diagnostics = MLJBase.diagnostics(y, input...; kwargs...) # defined in sources.jl
         if !isempty(mach)
             @error "Failed "*
                 "to apply the operation `$(y.operation)` to the machine "*
                 "$(y.machine), which receives it's data arguments from one or more "*
                 "nodes in a learning network. Possibly, one of these nodes "*
-                "is delivering data that is incompatible with the machine's model.\n"
+                "is delivering data that is incompatible "*
+                "with the machine's model.\n"*diagnostics
         else
             @error "Failed "*
-                "to apply the operation `$(y.operation)`."
+                "to apply the operation `$(y.operation)`."*diagnostics
         end
-        @error diagnostics(y, input...; kwargs...) # defined in sources.jl
         rethrow(exception)
     end
 end

--- a/src/composition/learning_networks/nodes.jl
+++ b/src/composition/learning_networks/nodes.jl
@@ -150,13 +150,18 @@ function _apply(y_plus, input...; kwargs...)
     try
         (y.operation)(mach..., raw_args...)
     catch exception
-        @error "Failed "*
-        "to apply the operation `$(y.operation)` to the machine "*
-        "$(y.machine), which receives it's data arguments from one or more "*
-        "nodes in a learning network. Possibly, one of these nodes "*
-        "is delivering data that is incompatible with the machine's model.\n"*
-        diagnostics(y, input...; kwargs...)
-        throw(exception)
+        if !isempty(mach)
+            @error "Failed "*
+                "to apply the operation `$(y.operation)` to the machine "*
+                "$(y.machine), which receives it's data arguments from one or more "*
+                "nodes in a learning network. Possibly, one of these nodes "*
+                "is delivering data that is incompatible with the machine's model.\n"
+        else
+            @error "Failed "*
+                "to apply the operation `$(y.operation)`."
+        end
+        @error diagnostics(y, input...; kwargs...) # defined in sources.jl
+        rethrow(exception)
     end
 end
 

--- a/src/sources.jl
+++ b/src/sources.jl
@@ -85,10 +85,21 @@ function diagnostics(X::AbstractNode, input...; kwargs...)
     _sources = sources(X)
     scitypes = scitype.(raw_args)
     mach = X.machine
-    model = mach.model
-    _input = input_scitype(model)
-    _target = target_scitype(model)
-    _output = output_scitype(model)
+
+    table0 = if !isnothing(mach)
+        model = mach.model
+        _input = input_scitype(model)
+        _target = target_scitype(model)
+        _output = output_scitype(model)
+        """
+        Model ($model):
+        input_scitype = $_input
+        target_scitype =$_target
+        output_scitype =$_output
+        """
+    else
+        ""
+    end
 
     table1 = "Incoming data:\n"*
     "arg of $(X.operation)\tscitype\n"*
@@ -97,11 +108,7 @@ function diagnostics(X::AbstractNode, input...; kwargs...)
 
     table2 =  diagnostic_table_sources(X)
     return """
-    Model ($model):
-    input_scitype = $_input
-    target_scitype =$_target
-    output_scitype =$_output
-
+    $table0
     $table1
     $table2"""
 end


### PR DESCRIPTION
The diagnostics currently fail in some cases because of access to non-existing fields of a `machine` when `machine` (attached to some `Node`) is actually `nothing`. 