### PR TITLE
Allow `Pipeline` and `TransformedTargetModel` to support feature importances

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MLJBase"
 uuid = "a7f614a8-145f-11e9-1d2a-a57a1082229d"
 authors = ["Anthony D. Blaom <anthony.blaom@gmail.com>"]
-version = "1.1.3"
+version = "1.2.0"
 
 [deps]
 CategoricalArrays = "324d7699-5711-5eae-9e2f-1d82baa6b597"

--- a/src/machines.jl
+++ b/src/machines.jl
@@ -808,10 +808,6 @@ julia> fitted_params(mach).logistic_classifier
  intercept = 0.0883301599726305,)
 ```
 
-Additional keys, `machines` and `fitted_params_given_machine`, give a
-list of *all* machines in the underlying network, and a dictionary of
-fitted parameters keyed on those machines.
-
 See also [`report`](@ref)
 
 """
@@ -851,10 +847,6 @@ julia> report(mach).linear_binary_classifier
  vcov = [3.592857686311793e8 9.122732393971942e6 … -8.454645589364915e7 5.38856837634321e6; 9.122732393971942e6 4.228700272808351e7 … -4.978433790526467e7 -8.442545425533723e6; … ; -8.454645589364915e7 -4.978433790526467e7 … 4.2662172244975924e8 2.1799125705781363e7; 5.38856837634321e6 -8.442545425533723e6 … 2.1799125705781363e7 4.456867590446599e6],)
 
 ```
-
-Additional keys, `machines` and `report_given_machine`, give a
-list of *all* machines in the underlying network, and a dictionary of
-reports keyed on those machines.
 
 See also [`fitted_params`](@ref)
 

--- a/test/composition/models/network_composite.jl
+++ b/test/composition/models/network_composite.jl
@@ -48,7 +48,7 @@ end
 MLJBase.reporting_operations(::Type{<:ReportingScaler}) = (:transform, )
 
 MLJBase.transform(model::ReportingScaler, _, X) = (
-    model.alpha*Tables.matrix(X),
+    Tables.table(model.alpha*Tables.matrix(X)),
     (; nrows = size(MLJBase.matrix(X))[1]),
 )
 
@@ -143,7 +143,7 @@ composite = WatermelonComposite(
         Set([:scaler, :clusterer, :classifier1, :training_loss, :len])
     @test fitr.scaler == (nrows=10,)
     @test fitr.clusterer == (labels=['A', 'B', 'C'],)
-    @test Set(keys(fitr.classifier1)) == Set([:classes_seen, :print_tree])
+    @test Set(keys(fitr.classifier1)) == Set([:classes_seen, :print_tree, :features])
     @test fitr.training_loss isa Real
     @test fitr.len == 10
 
@@ -164,7 +164,7 @@ composite = WatermelonComposite(
         Set([:scaler, :clusterer, :classifier1, :finalizer])
     @test predictr.scaler == (nrows=5,)
     @test predictr.clusterer == (labels=['A', 'B', 'C'],)
-    @test Set(keys(predictr.classifier1)) == Set([:classes_seen, :print_tree])
+    @test Set(keys(predictr.classifier1)) == Set([:classes_seen, :print_tree, :features])
     @test predictr.finalizer == (nrows=5,)
 
     o, predictr = predict(composite, f, selectrows(X, 1:2))
@@ -174,7 +174,7 @@ composite = WatermelonComposite(
         Set([:scaler, :clusterer, :classifier1, :finalizer])
     @test predictr.scaler == (nrows=2,)    # <----------- different
     @test predictr.clusterer == (labels=['A', 'B', 'C'],)
-    @test Set(keys(predictr.classifier1)) == Set([:classes_seen, :print_tree])
+    @test Set(keys(predictr.classifier1)) == Set([:classes_seen, :print_tree, :features])
     @test predictr.finalizer == (nrows=2,) # <---------- different
 
     r = MMI.report(composite, Dict(:fit => fitr, :predict=> predictr))

--- a/test/composition/models/pipelines.jl
+++ b/test/composition/models/pipelines.jl
@@ -690,6 +690,16 @@ end
     rm(filename)
 end
 
+@testset "feature importances" begin
+    # the DecisionTreeClassifier in /test/_models/ supports feature importances.
+    pipe = Standardizer |> DecisionTreeClassifier()
+    @test reports_feature_importances(pipe)
+    X, y = @load_iris
+    fitresult, _, report = MLJBase.fit(pipe, 0, X, y)
+    features = first.(feature_importances(pipe, fitresult, report))
+    @test Set(features) == Set(keys(X))
+end
+
 end # module
 
 true

--- a/test/composition/models/transformed_target_model.jl
+++ b/test/composition/models/transformed_target_model.jl
@@ -177,5 +177,14 @@ y = rand(5)
     @test training_losses(mach) == ones(5)
 end
 
+@testset "feature_importances" begin
+    X, y = @load_iris
+    atom = DecisionTreeClassifier()
+    model = TransformedTargetModel(atom, transformer=identity, inverse=identity)
+    @test reports_feature_importances(model)
+    fitresult, _, rpt = MMI.fit(model, 0, X, y)
+    @test Set(first.(feature_importances(model, fitresult, rpt))) == Set(keys(X))
+end
+
 end
 true


### PR DESCRIPTION
A model that supports features importances exposes these via the method `feature_importances`. However, these importances are hidden if the model is wrapped in `TransformedTargetModel` or is part of a pipeline. This PR implements `feature_importances` (and the trait `reports_feature_importances`) for these two wrappers by forwarding the atomic methods. 

For testing purposes, the test model `DecisionTreeClassifier` in /test/_models/DecisionTree.jl has been updated to support feature importances. 

@OkonSamuel 