### PR TITLE
Fix problem with training losses for pipelines

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MLJBase"
 uuid = "a7f614a8-145f-11e9-1d2a-a57a1082229d"
 authors = ["Anthony D. Blaom <anthony.blaom@gmail.com>"]
-version = "1.2.0"
+version = "1.2.1"
 
 [deps]
 CategoricalArrays = "324d7699-5711-5eae-9e2f-1d82baa6b597"

--- a/src/composition/models/pipelines.jl
+++ b/src/composition/models/pipelines.jl
@@ -602,20 +602,12 @@ MMI.target_scitype(p::SupervisedPipeline) = target_scitype(supervised_component(
 
 # ## Training losses
 
-const ERR_TRAINING_LOSSES1 = ErrorException(
-    "Looking for training losses in a model's report but cannot find any. "
-)
-
-const ERR_TRAINING_LOSSES2 = ErrorException(
-    "Composite model does not appear to support training losses. "
-)
-
+# If supervised model does not support training losses, we won't find an entry in the
+# report and so we need to return `nothing` (and not throw an error).
 function MMI.training_losses(pipe::SupervisedPipeline, pipe_report)
-    supports_training_losses(pipe::SupervisedPipeline) ||
-        throw(ERR_PIPE_TRAINING_LOSSES2)
     supervised = MLJBase.supervised_component(pipe)
     supervised_name = MLJBase.supervised_component_name(pipe)
-    supervised_name in propertynames(pipe_report) || throw(ERR_PIPE_TRAINING_LOSSES1)
+    supervised_name in propertynames(pipe_report) || return nothing
     report = getproperty(pipe_report, supervised_name)
     return training_losses(supervised, report)
 end


### PR DESCRIPTION
If a model does not support training losses then it must nevertheless return `nothing` (the fallback) but instead pipelines are throwing an error.

