### PR TITLE
Address some predict/transform type instabilities

### DIFF
--- a/src/composition/learning_networks/nodes.jl
+++ b/src/composition/learning_networks/nodes.jl
@@ -27,9 +27,9 @@ See also [`node`](@ref), [`Source`](@ref), [`origins`](@ref),
 [`sources`](@ref), [`fit!`](@ref).
 
 """
-struct Node{T<:Union{Machine, Nothing}} <: AbstractNode
+struct Node{T<:Union{Machine, Nothing},Oper} <: AbstractNode
 
-    operation   # eg, `predict` or a static operation, such as `exp`
+    operation::Oper   # eg, `predict` or a static operation, such as `exp`
     machine::T  # is `nothing` for static operations
 
     # nodes called to get args for `operation(model, ...) ` or
@@ -43,9 +43,11 @@ struct Node{T<:Union{Machine, Nothing}} <: AbstractNode
     # order consistent with extended graph, excluding self
     nodes::Vector{AbstractNode}
 
-    function Node(operation,
-                  machine::T,
-                  args::AbstractNode...) where T<:Union{Machine, Nothing}
+    function Node(
+        operation::Oper,
+        machine::T,
+        args::AbstractNode...,
+        ) where {T<:Union{Machine, Nothing}, Oper}
 
         # check the number of arguments:
         # if machine === nothing && isempty(args)
@@ -70,7 +72,7 @@ struct Node{T<:Union{Machine, Nothing}} <: AbstractNode
                 vcat(nodes_, (nodes(n) for n in machine.args)...) |> unique
         end
 
-        return new{T}(operation, machine, args, origins_, nodes_)
+        return new{T,Oper}(operation, machine, args, origins_, nodes_)
     end
 end
 

--- a/src/operations.jl
+++ b/src/operations.jl
@@ -74,12 +74,12 @@ for operation in OPERATIONS
     operation == :inverse_transform && continue
 
     ex = quote
-        function $(operation)(mach::Machine{<:Model,false}; rows=:)
+        function $(operation)(mach::Machine{<:Model,<:Any,false}; rows=:)
             # catch deserialized machine with no data:
             isempty(mach.args) && throw(err_serialized($operation))
             return ($operation)(mach, mach.args[1](rows=rows))
         end
-        function $(operation)(mach::Machine{<:Model,true}; rows=:)
+        function $(operation)(mach::Machine{<:Model,<:Any,true}; rows=:)
             # catch deserialized machine with no data:
             isempty(mach.args) && throw(err_serialized($operation))
             model = last_model(mach)
@@ -92,8 +92,10 @@ for operation in OPERATIONS
         end
 
         # special case of Static models (no training arguments):
-        $operation(mach::Machine{<:Static,true}; rows=:) = throw(ERR_ROWS_NOT_ALLOWED)
-        $operation(mach::Machine{<:Static,false}; rows=:) = throw(ERR_ROWS_NOT_ALLOWED)
+        $operation(mach::Machine{<:Static,<:Any,true}; rows=:) =
+            throw(ERR_ROWS_NOT_ALLOWED)
+        $operation(mach::Machine{<:Static,<:Any,false}; rows=:) =
+            throw(ERR_ROWS_NOT_ALLOWED)
     end
     eval(ex)
 

--- a/src/resampling.jl
+++ b/src/resampling.jl
@@ -1106,7 +1106,7 @@ end
 @static if VERSION >= v"1.3.0-DEV.573"
 
 # determines if an instantiated machine caches data:
-_caches_data(::Machine{M, C}) where {M, C} = C
+_caches_data(::Machine{<:Any,<:Any,C}) where C = C
 
 function _evaluate!(func, mach, accel::CPUThreads, nfolds, verbosity)
 

--- a/test/machines.jl
+++ b/test/machines.jl
@@ -272,7 +272,6 @@ end
     X = ones(2, 3)
 
     mach = @test_logs machine(Scale(2))
-    @test mach isa Machine{Scale, false}
     transform(mach, X) # triggers training of `mach`, ie is mutating
     @test report(mach) in [nothing, NamedTuple()]
     @test isnothing(fitted_params(mach))


### PR DESCRIPTION
This PR addresses a type instability for operations (`predict`, `transform`, etc) acting on machines, as  identified in #959 (although this PR does not resolve the particular issue there). 

I admit it is not clear to me that the performance gains here are likely to significantly benefit many use cases. But having done the work to identify these instabilities, I don't see much harm in including them. (Incidentally, the table below identifies some likely type instabilities *internal* to some third party implementations of the MLJ interface.)

The type instability is not difficult to address in the case of machines attached to ordinary models, by annotating a currently abstract type in the `Machine` struct. However, in the special case of a  machine attached to a *symbolic* model (which appear exclusively in learning networks), the type instability remains.

In 69 regression models, we compared the "high level"  `predict(::Machine, ...)` method with the "low level" `predict(::Model, ...)` method implemented by third party model providers. The benchmark code is hidden below:

<details>

```
using MLJTestInterface, MLJModels, MLJBase
using Tables
using Random
using BenchmarkTools
using Statistics
import DataFrames
import MLJModelInterface as MMI

const MODELS  = models() do m
    !(m.package_name in ["MLJText"]) &&
        AbstractVector{Continuous} <: m.target_scitype &&
        m.is_supervised
end

# This is a way to load all needed model code:
MLJTestInterface.test(MODELS, mod=@__MODULE__, level=1, throw=true)

rng = Random.MersenneTwister(0)
Xmat = randn(rng, 30, 3)
X = Tables.table(Xmat)
y = @. cos(Xmat[:, 1] * 2.1 - 0.9) * Xmat[:, 2] - Xmat[:, 3]

stats = []
for m in MODELS
    print("\rBenchmarking $(m.name) $(m.package_name).")
    model = eval(:(@load $(m.name) pkg=$(m.package_name) verbosity=0))()
    mach = machine(model, X, y)
    fit!(mach, verbosity=0)
    fitresult = mach.fitresult
    b_high = @benchmark predict($mach, $X)
    b_low = @benchmark predict($model, $fitresult, $(MMI.reformat(model, X))...)
    slow_down = median(b_high.times)/median(b_low.times)
    bloat = b_high.allocs/b_low.allocs
    push!(stats, (; model=m.name, pkg=m.package_name, slow_down, bloat))
    print(" Done.                           ")
end

@show length(MODELS)
#length(MODELS) = 69

stats = DataFrames.DataFrame([stats...])
filter(stats) do row
    row.slow_down > 1.75 || row.bloat > 2.0
end
```

</details>

In the tables below: 

- "slow_down" is the ratio of elapsed **time** of "high" to "low"
- "bloat" is the ratio of number of **allocations** of "high" to "low"

Only models with `slow_down > 1.75` or `bloat > 2` are reported.

### Before this PR

```julia
#  Row │ model                           pkg                           slow_down  bloat
#      │ String                          String                        Float64    Float64
# ─────┼───────────────────────────────────────────────────────────────────────────────────
#    1 │ CatBoostRegressor               CatBoost                       99.694    20.875
#    2 │ ConstantRegressor               MLJModels                       8.50998   4.0
#    3 │ DeterministicConstantRegressor  MLJModels                      12.8771    4.0
#    4 │ ElasticNetRegressor             MLJLinearModels                 4.67751   2.0
#    5 │ EvoLinearRegressor              EvoLinear                      18.5536    7.33333
#    6 │ EvoSplineRegressor              EvoLinear                       4.11118   2.05556
#    7 │ HuberRegressor                  MLJLinearModels                 4.18327   2.0
#    8 │ LADRegressor                    MLJLinearModels                 4.18333   2.0
#    9 │ LassoRegressor                  MLJLinearModels                 4.07216   2.0
#   10 │ LinearRegressor                 MLJLinearModels                 4.05314   2.0
#   11 │ LinearRegressor                 MultivariateStats               4.77403   2.5
#   12 │ PLSRegressor                    PartialLeastSquaresRegressor    2.11986   1.375
#   13 │ QuantileRegressor               MLJLinearModels                 4.33039   2.0
#   14 │ RidgeRegressor                  MLJLinearModels                 4.12531   2.0
#   15 │ RidgeRegressor                  MultivariateStats               4.8491    2.5
#   16 │ RobustRegressor                 MLJLinearModels                 4.17605   2.0
```

### After this PR:

```
#  Row │ model               pkg        slow_down  bloat
#      │ String              String     Float64    Float64
# ─────┼────────────────────────────────────────────────────
#    1 │ CatBoostRegressor   CatBoost    96.6566   20.8125
#    2 │ ConstantRegressor   MLJModels    1.55635   3.0
#    3 │ EvoLinearRegressor  EvoLinear   19.9274    7.0
#    4 │ EvoSplineRegressor  EvoLinear    4.52508   2.0
#    5 │ EvoTreeMLE          EvoTrees     2.46669   1.00031
```

Note this machines serialised using #master cannot be deserialised after this PR. But I don't consider this triggers a breaking release. 

To do:

- [ ] Run MLJ tests with integration tests switched on

