### PR TITLE
Add `CompactPerformanceEvaluation` objects and the option in `evaluate!` to construct them

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
         env:
           JULIA_NUM_THREADS: 2
       - uses: julia-actions/julia-processcoverage@v1
-      - uses: codecov/codecov-action@v1
+      - uses: codecov/codecov-action@v3
         with:
           file: lcov.info
   docs:

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MLJBase"
 uuid = "a7f614a8-145f-11e9-1d2a-a57a1082229d"
 authors = ["Anthony D. Blaom <anthony.blaom@gmail.com>"]
-version = "1.2.1"
+version = "1.3"
 
 [deps]
 CategoricalArrays = "324d7699-5711-5eae-9e2f-1d82baa6b597"

--- a/src/MLJBase.jl
+++ b/src/MLJBase.jl
@@ -292,7 +292,7 @@ export TransformedTargetModel
 
 # resampling.jl:
 export ResamplingStrategy, Holdout, CV, StratifiedCV, TimeSeriesCV,
-    evaluate!, Resampler, PerformanceEvaluation
+    evaluate!, Resampler, PerformanceEvaluation, CompactPerformanceEvaluation
 
 # `MLJType` and the abstract `Model` subtypes are exported from within
 # src/composition/abstract_types.jl

--- a/src/machines.jl
+++ b/src/machines.jl
@@ -51,8 +51,10 @@ mutable struct Machine{M,OM,C} <: MLJType
 
     model::M
     old_model::OM  # for remembering the model used in last call to `fit!`
+
+    # the next two refer to objects returned by `MLJModlelInterface.fit(::M, ...)`.
     fitresult
-    cache
+    cache # relevant to `MLJModelInterface.update`, not to be confused with type param `C`
 
     # training arguments (`Node`s or user-specified data wrapped in
     # `Source`s):
@@ -81,7 +83,7 @@ mutable struct Machine{M,OM,C} <: MLJType
         # In the case of symbolic model, machine cannot know the type of model to be fit
         # at time of construction:
         OM = M == Symbol ? Any : M
-        mach = new{M,OM,cache}(model)
+        mach = new{M,OM,cache}(model) # (this `cache` is not the *field* `cache`)
         mach.frozen = false
         mach.state = 0
         mach.args = args
@@ -91,6 +93,8 @@ mutable struct Machine{M,OM,C} <: MLJType
     end
 
 end
+
+caches_data(::Machine{<:Any, <:Any, C}) where C = C
 
 """
     age(mach::Machine)

--- a/src/resampling.jl
+++ b/src/resampling.jl
@@ -568,7 +568,7 @@ Type of object returned by [`evaluate`](@ref) (for models plus data) or
 [`evaluate!`](@ref) (for machines) when called with the option `compact = true`. Such
 objects have the same structure as the [`PerformanceEvaluation`](@ref) objects returned by
 default, except that the following fields are omitted to save memory:
-`fitted_params_per_fold`, `report_per_fold`, `train_test_rows`.
+`fitted_params_per_fold`, `report_per_fold`.
 
 For more on the remaining fields, see [`PerformanceEvaluation`](@ref).
 
@@ -586,6 +586,7 @@ struct CompactPerformanceEvaluation{M,
     operation::Operation
     per_fold::PerFold
     per_observation::PerObservation
+    train_test_rows::TrainTestPairs
     resampling::R
     repeats::Int
 end
@@ -652,7 +653,7 @@ function Base.show(io::IO, ::MIME"text/plain", e::AbstractPerformanceEvaluation)
             "with these fields:")
         println(io, "  model, measure, operation,\n"*
             "  measurement, per_fold, per_observation,\n"*
-            "  resampling, repeats")
+            "  train_test_rows, resampling, repeats")
     end
     println(io, "Extract:")
     show_color = MLJBase.SHOW_COLOR[]
@@ -1421,6 +1422,7 @@ function evaluate!(
         operations,
         per_fold,
         per_observation,
+        resampling,
         user_resampling,
         repeats,
         )

--- a/src/resampling.jl
+++ b/src/resampling.jl
@@ -1464,6 +1464,7 @@ end
         check_measure=true,
         per_observation=true,
         logger=nothing,
+        compact=false,
     )
 
 Resampling model wrapper, used internally by the `fit` method of `TunedModel` instances
@@ -1507,6 +1508,7 @@ mutable struct Resampler{S, L} <: Model
     cache::Bool
     per_observation::Bool
     logger::L
+    compact::Bool
 end
 
 # Some traits are markded as `missing` because we cannot determine
@@ -1550,6 +1552,7 @@ function Resampler(
     cache=true,
     per_observation=true,
     logger=nothing,
+    compact=false,
 )
     resampler = Resampler(
         model,
@@ -1564,6 +1567,7 @@ function Resampler(
         cache,
         per_observation,
         logger,
+        compact,
     )
     message = MLJModelInterface.clean!(resampler)
     isempty(message) || @warn message
@@ -1612,6 +1616,7 @@ function MLJModelInterface.fit(resampler::Resampler, verbosity::Int, args...)
         resampler.per_observation,
         resampler.logger,
         resampler.resampling,
+        resampler.compact,
     )
 
     fitresult = (machine = mach, evaluation = e)
@@ -1685,6 +1690,7 @@ function MLJModelInterface.update(
         resampler.per_observation,
         resampler.logger,
         resampler.resampling,
+        resampler.compact,
     )
     report = (evaluation = e, )
     fitresult = (machine=mach2, evaluation=e)

--- a/src/resampling.jl
+++ b/src/resampling.jl
@@ -532,7 +532,8 @@ These fields are part of the public API of the `PerformanceEvaluation` struct.
   and `test` are vectors of row (observation) indices for training and evaluation
   respectively.
 
-- `resampling`: the resampling strategy used to generate the train/test pairs.
+- `resampling`: the user-specified resampling strategy to generate the train/test pairs
+  (or literal train/test pairs if that was directly specified).
 
 - `repeats`: the number of times the resampling strategy was repeated.
 
@@ -999,6 +1000,7 @@ function evaluate!(
     per_observation=true,
     verbosity=1,
     logger=nothing,
+    compact=false,
     )
 
     # this method just checks validity of options, preprocess the
@@ -1065,6 +1067,7 @@ function evaluate!(
         per_observation,
         logger,
         resampling,
+        compact,
     )
 end
 
@@ -1246,6 +1249,7 @@ function evaluate!(
     per_observation_flag,
     logger,
     user_resampling,
+    compact,
     )
 
     # Note: `user_resampling` keyword argument is the user-defined resampling strategy,
@@ -1385,7 +1389,19 @@ function evaluate!(
         )
     end
 
-    evaluation = PerformanceEvaluation(
+    if compact
+        evaluation = CompactPerformanceEvaluation(
+        mach.model,
+        measures,
+        per_measure,
+        operations,
+        per_fold,
+        per_observation,
+        user_resampling,
+        repeats,
+        )
+    else
+        evaluation = PerformanceEvaluation(
         mach.model,
         measures,
         per_measure,
@@ -1397,7 +1413,8 @@ function evaluate!(
         resampling,
         user_resampling,
         repeats
-    )
+        )
+    end 
     log_evaluation(logger, evaluation)
 
     evaluation

--- a/src/resampling.jl
+++ b/src/resampling.jl
@@ -1000,7 +1000,11 @@ Although `evaluate!` is mutating, `mach.model` and `mach.args` are not mutated.
 
 - `logger` - a logger object (see [`MLJBase.log_evaluation`](@ref))
 
-See also [`evaluate`](@ref), [`PerformanceEvaluation`](@ref)
+- `compact=false` - if `true`, the returned evaluation object excludes these fields:
+  `fitted_params_per_fold`, `report_per_fold`, `train_test_rows`.
+
+See also [`evaluate`](@ref), [`PerformanceEvaluation`](@ref),
+[`CompactPerformanceEvaluation`](@ref).
 
 """
 function evaluate!(

--- a/test/machines.jl
+++ b/test/machines.jl
@@ -68,7 +68,12 @@ end
     predict(t, selectrows(X,test));
     @test rms(predict(t, selectrows(X, test)), y[test]) < std(y)
 
+    # cache type parameter
+    mach = machine(ConstantRegressor(), X, y, cache=false)
+    @test !MLJBase.caches_data(mach)
     mach = machine(ConstantRegressor(), X, y)
+    @test MLJBase.caches_data(mach)
+
     @test_logs (:info, r"Training") fit!(mach)
     yhat = predict_mean(mach, X);
 

--- a/test/resampling.jl
+++ b/test/resampling.jl
@@ -348,7 +348,7 @@ end
     model = Models.DeterministicConstantRegressor()
 
     for cache in [true, false]
-        mach = machine(model, X, y, cache=cache) 
+        mach = machine(model, X, y, cache=cache)
         result = evaluate!(mach, resampling=holdout, verbosity=verb,
                        measure=[rms, rmslp1], repeats=6)
         per_fold = result.per_fold[1]
@@ -661,7 +661,7 @@ end
     e = evaluate(ConstantClassifier(), X, y,
                  measure=misclassification_rate,
                  resampling=DummyResamplingStrategy(),
-                 operaton=predict_mode,
+                 operation=predict_mode,
                  acceleration=accel,
                  verbosity=verb)
     @test e.measurement[1] ≈ 1.0
@@ -901,6 +901,20 @@ end
     @test startswith(sprint(show, MIME("text/plain"), e), "PerformanceEvaluation")
     @test startswith(sprint(show, MIME("text/plain"), ec), "CompactPerformanceEvaluation")
     @test e.measurement[1] == ec.measurement[1]
+
+    # smoke tests:
+    mach = machine(model, X, y)
+    for e in [
+        evaluate!(mach, measures=[brier_loss, accuracy]),
+        evaluate!(mach, measures=[brier_loss, accuracy], compact=true),
+        evaluate!(mach, resampling=CV(), measures=[brier_loss, accuracy]),
+        evaluate!(mach, resampling=CV(), measures=[brier_loss, accuracy], compact=true),
+        ]
+        @test contains(sprint(show, MIME("text/plain"), e), "predict")
+        @test contains(sprint(show, MIME("text/plain"), e), "[")
+        @test contains(sprint(show, e), "PerformanceEvaluation(")
+        @test !contains(sprint(show, e), "predict")
+    end
 end
 
 true

--- a/test/resampling.jl
+++ b/test/resampling.jl
@@ -896,6 +896,7 @@ end
     X, y = make_blobs(10)
     e = evaluate(model, X, y)
     ec = evaluate(model, X, y, compact=true)
+    @test MLJBase.compactify(ec) == ec == MLJBase.compactify(e)
     @test e isa PerformanceEvaluation
     @test ec isa CompactPerformanceEvaluation
     @test startswith(sprint(show, MIME("text/plain"), e), "PerformanceEvaluation")

--- a/test/resampling.jl
+++ b/test/resampling.jl
@@ -911,9 +911,7 @@ end
         evaluate!(mach, resampling=Holdout(), measures=[brier_loss, accuracy], compact=true),
         ]
         @test contains(sprint(show, MIME("text/plain"), e), "predict")
-        @test contains(sprint(show, MIME("text/plain"), e), "[")
         @test contains(sprint(show, e), "PerformanceEvaluation(")
-        @test !contains(sprint(show, e), "predict")
     end
 end
 

--- a/test/resampling.jl
+++ b/test/resampling.jl
@@ -907,8 +907,8 @@ end
     for e in [
         evaluate!(mach, measures=[brier_loss, accuracy]),
         evaluate!(mach, measures=[brier_loss, accuracy], compact=true),
-        evaluate!(mach, resampling=CV(), measures=[brier_loss, accuracy]),
-        evaluate!(mach, resampling=CV(), measures=[brier_loss, accuracy], compact=true),
+        evaluate!(mach, resampling=Holdout(), measures=[brier_loss, accuracy]),
+        evaluate!(mach, resampling=Holdout(), measures=[brier_loss, accuracy], compact=true),
         ]
         @test contains(sprint(show, MIME("text/plain"), e), "predict")
         @test contains(sprint(show, MIME("text/plain"), e), "[")

--- a/test/resampling.jl
+++ b/test/resampling.jl
@@ -896,7 +896,7 @@ end
     X, y = make_blobs(10)
     e = evaluate(model, X, y)
     ec = evaluate(model, X, y, compact=true)
-    @test e isa PeformanceEvaluation
+    @test e isa PerformanceEvaluation
     @test ec isa CompactPerformanceEvaluation
     @test startswith(sprint(show, MIME("text/plain"), e), "PerformanceEvaluation")
     @test startswith(sprint(show, MIME("text/plain"), ec), "CompactPerformanceEvaluation")

--- a/test/resampling.jl
+++ b/test/resampling.jl
@@ -891,4 +891,16 @@ end
     fit!(mach)
 end
 
+@testset "compact evaluation objects" begin
+    model = ConstantClassifier()
+    X, y = make_blobs(10)
+    e = evaluate(model, X, y)
+    ec = evaluate(model, X, y, compact=true)
+    @test e isa PeformanceEvaluation
+    @test ec isa CompactPerformanceEvaluation
+    @test startswith(sprint(show, MIME("text/plain"), e), "PerformanceEvaluation")
+    @test startswith(sprint(show, MIME("text/plain"), ec), "CompactPerformanceEvaluation")
+    @test e.measurement[1] == ec.measurement[1]
+end
+
 true

--- a/test/resampling.jl
+++ b/test/resampling.jl
@@ -348,7 +348,7 @@ end
     model = Models.DeterministicConstantRegressor()
 
     for cache in [true, false]
-        mach = machine(model, X, y, cache=cache)
+        mach = machine(model, X, y, cache=cache) 
         result = evaluate!(mach, resampling=holdout, verbosity=verb,
                        measure=[rms, rmslp1], repeats=6)
         per_fold = result.per_fold[1]
@@ -661,7 +661,7 @@ end
     e = evaluate(ConstantClassifier(), X, y,
                  measure=misclassification_rate,
                  resampling=DummyResamplingStrategy(),
-                 operation=predict_mode,
+                 operaton=predict_mode,
                  acceleration=accel,
                  verbosity=verb)
     @test e.measurement[1] ≈ 1.0


### PR DESCRIPTION
Partly addresses https://github.com/alan-turing-institute/MLJ.jl/issues/1105, and prepares for https://github.com/JuliaAI/MLJTuning.jl/pull/215.

~~This PR also drops the `per_fold` part of `PerformanceEvaluation` display. More often than not, the table does not fit with this in it. The display still includes the names of all accessible fields.~~ This PR also adjusts the display of `per_fold` information to mitigate issue with overly wide table.

Previously:

```julia
PerformanceEvaluation object with these fields:
  model, measure, operation, measurement, per_fold,
  per_observation, fitted_params_per_fold,
  report_per_fold, train_test_rows, resampling, repeats
Extract:
┌─────────────┬──────────────┬─────────────┬─────────┬──────────────────────────────────────
│ measure     │ operation    │ measurement │ 1.96*SE │ per_fold                            ⋯
├─────────────┼──────────────┼─────────────┼─────────┼──────────────────────────────────────
│ BrierLoss() │ predict      │ 0.933       │ 0.184   │ [0.719, 1.16, 0.844, 1.16, 0.667, 0 ⋯
│ Accuracy()  │ predict_mode │ 0.0         │ 0.0     │ [0.0, 0.0, 0.0, 0.0, 0.0, 0.0]      ⋯
└─────────────┴──────────────┴─────────────┴─────────┴──────────────────────────────────────
 ```

After this PR:

```julia
PerformanceEvaluation object with these fields:
  model, measure, operation,
  measurement, per_fold, per_observation,
  fitted_params_per_fold, report_per_fold,
  train_test_rows, resampling, repeats
Extract:
┌───┬─────────────┬──────────────┬─────────────┐
│   │ measure     │ operation    │ measurement │
├───┼─────────────┼──────────────┼─────────────┤
│ A │ BrierLoss() │ predict      │ 0.933       │
│ B │ Accuracy()  │ predict_mode │ 0.0         │
└───┴─────────────┴──────────────┴─────────────┘
┌───┬──────────────────────────────────────────┬─────────┐
│   │ per_fold                                 │ 1.96*SE │
├───┼──────────────────────────────────────────┼─────────┤
│ A │ [0.719, 1.16, 0.844, 1.16, 0.667, 0.914] │ 0.184   │
│ B │ [0.0, 0.0, 0.0, 0.0, 0.0, 0.0]           │ 0.0     │
└───┴──────────────────────────────────────────┴─────────┘
```
To do:

- [x] Check this does not interfere with logging (MLJFlow.jl tests ok)
- [x] Run MLJ integration tests
- [x] Changes are sufficient for planned MLJTuning.jl change (see https://github.com/alan-turing-institute/MLJ.jl/issues/1105) 
- [x] Check `Stack` not broken by addition of `evaluate!` arguments