### PR TITLE
Relax restrictions on model type in resampling (`evaluate!`)

### DIFF
--- a/src/resampling.jl
+++ b/src/resampling.jl
@@ -68,7 +68,7 @@ err_ambiguous_operation(model, measure) = ArgumentError(
     "Possible value(s) are: $PREDICT_OPERATIONS_STRING. "
 )
 
-ERR_UNSUPPORTED_PREDICTION_TYPE = ArgumentError(
+const ERR_UNSUPPORTED_PREDICTION_TYPE = ArgumentError(
     """
 
     The `prediction_type` of your model needs to be one of: `:deterministic`,
@@ -79,6 +79,18 @@ ERR_UNSUPPORTED_PREDICTION_TYPE = ArgumentError(
     evaluation is not supported.
 
    """
+)
+
+const ERR_NEED_TARGET = ArgumentError(
+   """
+
+    To evaluate a model's performance you must provide a target variable `y`, as in
+    `evaluate(model, X, y; options...)` or
+
+        mach = machine(model, X, y)
+        evaluate!(mach; options...)
+
+    """
 )
 
 # ==================================================================
@@ -1169,6 +1181,8 @@ function evaluate!(
     # this method just checks validity of options, preprocess the
     # weights, measures, operations, and dispatches a
     # strategy-specific `evaluate!`
+
+    length(mach.args) > 1 || throw(ERR_NEED_TARGET)
 
     repeats > 0 || error("Need `repeats > 0`. ")
 

--- a/test/resampling.jl
+++ b/test/resampling.jl
@@ -118,7 +118,7 @@ API.@trait(
         MLJBase._actual_operations(nothing,
                                    [LogLoss(), ], dummy_interval, 1))
 
-    # model not have a valid `prediction_type`:
+    # model does not have a valid `prediction_type`:
     @test_throws(
         MLJBase.ERR_UNSUPPORTED_PREDICTION_TYPE,
         MLJBase._actual_operations(nothing, [LogLoss(),], GoofyTransformer(), 0),

--- a/test/resampling.jl
+++ b/test/resampling.jl
@@ -948,7 +948,9 @@ end
 
 struct PredictingTransformer <:Unsupervised end
 MLJBase.fit(::PredictingTransformer, verbosity, X, y) = (mean(y), nothing, nothing)
+MLJBase.fit(::PredictingTransformer, verbosity, X) = (nothing, nothing, nothing)
 MLJBase.predict(::PredictingTransformer, fitresult, X) = fill(fitresult, nrows(X))
+MLJBase.predict(::PredictingTransformer, ::Nothing, X) = nothing
 MLJBase.prediction_type(::Type{<:PredictingTransformer}) = :deterministic
 
 @testset "`Unsupervised` model with a predict" begin
@@ -956,6 +958,10 @@ MLJBase.prediction_type(::Type{<:PredictingTransformer}) = :deterministic
     y = fill(42.0, 10)
     e = evaluate(PredictingTransformer(), X, y, resampling=Holdout(), measure=l2)
     @test e.measurement[1] ≈ 0
+    @test_throws(
+        MLJBase.ERR_NEED_TARGET,
+        evaluate(PredictingTransformer(), X, measure=l2),
+    )
 end
 
 


### PR DESCRIPTION
### Current behaviour

Currently a model in `evaluate`/`evaluate!` must subtype `Supervised` or `Annotator`. However, in the current implementation, all that's essential for the model is: 

- It implements a `predict` method
- It's `fit` method consumes a target `y` (which must be provided in the `evaluate` call, or `machine` constructor).
-  In the common case that `operation` is left unspecified, `MLJModelnterface.prediction_type` must be one of: `:deterministic`, `:probabilistic`, `:interval`. 

Subtypes of `Annotator` and `Supervised` (e.g,`Probabilistic`, `Deterministic`, `Interval`) have the obvious `prediction_type` fallbacks, but the fallback for `Unsupervised` models is `:unknown`. 

### What this PR does

This PR:

- Removes the current model type restriction: Now any `<:Model` is now allowed.
- Adds the currently missing check that a target `y` has been provided.
- In the case that an operation is not specified, and the `prediction_type` is not one of `:deterministic`, `:probabilistic`, `:interval`, the error which is already thrown in that case is made more informative. It now suggests two remedies: (i) explicitly specify `operation`(s), or (ii) post an issue to have the model's `prediction_type` reviewed. 


### Context

More and more we are relying on traits and less on the abstract model hierarchy. Currently, however, only `Unsupervised` models can have their `transform` method propagated in a `Pipeline` (and `predict` is propagated by `Supervised` models). So some models want to be `Unsupervised` for pipeline use, despite the fact they are also "supervised" - a case in point is `RecursiveFeatureElimination` (currently `Supervised` and so not pipelinable). 

### To do

Just to be sure, let's wait for 

- [x] Run local MLJ integration tests (@ablaom)

### Afterword

We should ultimately like to evaluate models that do *not* consume a target in training, such as clustering models. In that case, the target is only supplied for the test sets (e.g., for computing the [Rand index](https://en.wikipedia.org/wiki/Rand_index)). However, that requires a more substantial redesign of `evaluate`. 
