### PR TITLE
Fix deprecated `Vararg` expression

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MLJBase"
 uuid = "a7f614a8-145f-11e9-1d2a-a57a1082229d"
 authors = ["Anthony D. Blaom <anthony.blaom@gmail.com>"]
-version = "1.8.0"
+version = "1.8.1"
 
 [deps]
 CategoricalArrays = "324d7699-5711-5eae-9e2f-1d82baa6b597"

--- a/src/interface/data_utils.jl
+++ b/src/interface/data_utils.jl
@@ -132,7 +132,7 @@ end
 
 function project(
     t::NamedTuple,
-    indices::Tuple{<:Any,Vararg{<:Integer}},
+    indices::Tuple{<:Any,Vararg{Integer}},
     )
     return NamedTuple{tuple(keys(t)[[indices...]]...)}(tuple([t[i] for i in indices]...))
 end


### PR DESCRIPTION
https://github.com/JuliaAI/MLJBase.jl/pull/992 and thereby release 1.8.0 broke MLJBase:
```
ERROR: LoadError: Wrapping `Vararg` directly in UnionAll is deprecated (wrap the tuple instead).
You may need to write `f(x::Vararg{T})` rather than `f(x::Vararg{<:T})` or `f(x::Vararg{T}) where T` instead of `f(x::Vararg{T} where T)`.
Stacktrace:
 [1] UnionAll(v::Any, t::Any)
   @ Core ./boot.jl:299
 [2] top-level scope
   @ ~/.julia/packages/MLJBase/5aKTB/src/interface/data_utils.jl:133
 [3] include(mod::Module, _path::String)
   @ Base ./Base.jl:557
 [4] include(x::String)
   @ MLJBase ~/.julia/packages/MLJBase/5aKTB/src/MLJBase.jl:1
 [5] top-level scope
   @ ~/.julia/packages/MLJBase/5aKTB/src/MLJBase.jl:149
 [6] include
   @ ./Base.jl:557 [inlined]
 [7] include_package_for_output(pkg::Base.PkgId, input::String, depot_path::Vector{String}, dl_load_path::Vector{String}, load_path::Vector{String}, concrete_deps::Vector{Pair{Base.PkgId, UInt128}}, source::String)
   @ Base ./loading.jl:2881
 [8] top-level scope
   @ stdin:6
in expression starting at /build/.julia/packages/MLJBase/5aKTB/src/interface/data_utils.jl:133
in expression starting at /build/.julia/packages/MLJBase/5aKTB/src/MLJBase.jl:1
in expression starting at stdin:6
ERROR: LoadError: Failed to precompile MLJBase [a7f614a8-145f-11e9-1d2a-a57a1082229d] to "/build/.julia/compiled/v1.11/MLJBase/jl_KDRdpO".
...
```

This PR fixes the deprecated `Vararg` expression introduced in #992. This error actually showed up in the CI of #992, e.g. https://github.com/JuliaAI/MLJBase.jl/actions/runs/14047109795/job/39330222537#step:6:402, but since CI was not run with `--depwarn=error` they did not lead to a test failure but only a warning in the logs. In this PR, however, no such warnings show up in the CI logs.