### PR TITLE
Ensure `source()  != source()` and clean up some tests

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MLJBase"
 uuid = "a7f614a8-145f-11e9-1d2a-a57a1082229d"
 authors = ["Anthony D. Blaom <anthony.blaom@gmail.com>"]
-version = "1.8.1"
+version = "1.8.2"
 
 [deps]
 CategoricalArrays = "324d7699-5711-5eae-9e2f-1d82baa6b597"

--- a/src/composition/learning_networks/inspection.jl
+++ b/src/composition/learning_networks/inspection.jl
@@ -115,17 +115,6 @@ train_args(N::Node{<:Machine}) = N.machine.args
 train_args(N::Node{Nothing}) = []
 
 """
-    children(N::AbstractNode, y::AbstractNode)
-
-List all (immediate) children of node `N` in the ancestor graph of `y`
-(training edges included).
-
-"""
-children(N::AbstractNode, y::AbstractNode) = filter(nodes(y)) do W
-    N in args(W) || N in train_args(W)
-end |> unique
-
-"""
     lower_bound(type_itr)
 
 Return the minimum type in the collection `type_itr` if one exists

--- a/src/sources.jl
+++ b/src/sources.jl
@@ -30,6 +30,9 @@ mutable struct Source <: AbstractNode
     scitype::DataType
 end
 
+# To ensure `source() != source()`:
+MMI.is_same_except(s1::Source, s2::Source; kwargs...) = s1 === s2
+
 """
     Xs = source(X=nothing)
 

--- a/test/composition/learning_networks/inspection.jl
+++ b/test/composition/learning_networks/inspection.jl
@@ -3,8 +3,20 @@ module TestLearningCompositesInspection
 using Test
 using MLJBase
 using ..Models
+import MLJModelInterface as MMI
 
-KNNRegressor()
+"""
+    children(N::AbstractNode, y::AbstractNode)
+
+List all (immediate) children of node `N` in the ancestor graph of `y`
+(training edges included).
+
+"""
+children(N::AbstractNode, y::AbstractNode) = filter(nodes(y)) do Z
+    t = MMI.isrepresented(N, MLJBase.args(Z)) ||
+        MMI.isrepresented(N, MLJBase.train_args(Z))
+    @show Z t
+end |> unique
 
 @constant X = source()
 @constant y = source()
@@ -36,12 +48,12 @@ knnM = machine(knn, W, y)
 @test Set(machines(yhat)) == Set([knnM, hotM])
 @test Set(MLJBase.args(yhat)) == Set([W, ])
 @test Set(MLJBase.train_args(yhat)) == Set([W, y])
-@test Set(MLJBase.children(X, all)) == Set([W, K])
+@test Set(children(X, all)) == Set([W, K])
 
 @constant Q = 2X
 @constant R = 3X
 @constant S = glb(X, Q, R)
-@test Set(MLJBase.children(X, S)) == Set([Q, R, S])
+@test Set(children(X, S)) == Set([Q, R, S])
 @test MLJBase.lower_bound([Int, Float64]) == Union{}
 @test MLJBase.lower_bound([Int, Integer]) == Int
 @test MLJBase.lower_bound([Int, Integer]) == Int

--- a/test/sources.jl
+++ b/test/sources.jl
@@ -13,6 +13,7 @@ Xs = source(X)
 rebind!(Xs, nothing)
 @test isempty(Xs)
 @test Xs.scitype == Nothing
+@test source() != source()
 
 end
 true


### PR DESCRIPTION
At present `source() == source()`, which means sources unbound to data in learning networks cannot be distinguished using `==`, which we view as a bug. This PR fixes this.

We also move the definition of the private method `MLJBase.children` out to tests, since it is not used for any other purpose. Moreover, we tweak its definition so that it does not depend on the overloading of `Base.in` currently in MLJModelInterface, which we would ultimately like to remove. 