### PR TITLE
Allow tuples in the `resampling` option for `evaluate`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MLJBase"
 uuid = "a7f614a8-145f-11e9-1d2a-a57a1082229d"
 authors = ["Anthony D. Blaom <anthony.blaom@gmail.com>"]
-version = "1.8.2"
+version = "1.9.0"
 
 [deps]
 CategoricalArrays = "324d7699-5711-5eae-9e2f-1d82baa6b597"

--- a/src/resampling.jl
+++ b/src/resampling.jl
@@ -1,8 +1,11 @@
-# TYPE ALIASES
+# # LOCAL TYPE ALIASES
 
 const AbstractRow = Union{AbstractVector{<:Integer}, Colon}
-const TrainTestPair = Tuple{AbstractRow,AbstractRow}
-const TrainTestPairs = AbstractVector{<:TrainTestPair}
+const TrainTestPair = Tuple{AbstractRow, AbstractRow}
+const TrainTestPairs = Union{
+    NTuple{<:Any,TrainTestPair},
+    AbstractVector{<:TrainTestPair},
+}
 
 
 # # ERROR MESSAGES
@@ -92,6 +95,13 @@ const ERR_NEED_TARGET = ArgumentError(
 
     """
 )
+
+const ERR_BAD_RESAMPLING_OPTION = ArgumentError(
+    "`resampling` must be an "*
+        "`MLJ.ResamplingStrategy` or a vector (or tuple) of tuples "*
+        "of the form `(train_rows, test_rows)`"
+)
+
 
 # ==================================================================
 ## RESAMPLING STRATEGIES
@@ -1402,10 +1412,6 @@ end
 # ------------------------------------------------------------
 # Core `evaluation` method, operating on train-test pairs
 
-const AbstractRow = Union{AbstractVector{<:Integer}, Colon}
-const TrainTestPair = Tuple{AbstractRow, AbstractRow}
-const TrainTestPairs = AbstractVector{<:TrainTestPair}
-
 _view(::Nothing, rows) = nothing
 _view(weights, rows) = view(weights, rows)
 
@@ -1434,11 +1440,7 @@ function evaluate!(
     # Note: `rows` and `repeats` are only passed to the final `PeformanceEvaluation`
     # object to be returned and are not otherwise used here.
 
-    if !(resampling isa TrainTestPairs)
-        error("`resampling` must be an "*
-              "`MLJ.ResamplingStrategy` or tuple of rows "*
-              "of the form `(train_rows, test_rows)`")
-    end
+    resampling isa TrainTestPairs || throw(ERR_BAD_RESAMPLING_OPTION)
 
     X = mach.args[1]()
     y = mach.args[2]()

--- a/test/resampling.jl
+++ b/test/resampling.jl
@@ -276,6 +276,19 @@ end
         model = DeterministicConstantRegressor()
         mach  = machine(model, X, y, cache=cache)
 
+        # check catch for bad `resampling` option:
+        @test_throws(
+            MLJBase.ERR_BAD_RESAMPLING_OPTION,
+            evaluate(model, X, y; resampling="junk", verbosity=0, acceleration=accel),
+        )
+
+        # check we can provide tuples of pairs, instead of vectors of pairs, in
+        # `resampling` option:
+        e1 = evaluate(model, X, y; resampling, verbosity=0, acceleration=accel)
+        e2 = evaluate(model, X, y;
+                      resampling=Tuple(resampling), verbosity=0, acceleration=accel)
+        @test e1.measurement[1] ≈ e2.measurement[1]
+
         # check detection of incompatible measure (cross_entropy):
         @test_throws(
             MLJBase.err_incompatible_prediction_types(model, cross_entropy),


### PR DESCRIPTION
At the moment you can specify a *vector* of pairs of the form `(train, test)` when specifying `resampling=...` in an `evaluate` or `evaluate!` call. If you specify a *tuple* instead, you get a misleading error message saying you need to specify a tuple!

In this PR we:

- [ ] Allow tuples, in addition to vectors
- [ ] Fix the error message
