### PR TITLE
For a 1.9 release

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MLJBase"
 uuid = "a7f614a8-145f-11e9-1d2a-a57a1082229d"
 authors = ["Anthony D. Blaom <anthony.blaom@gmail.com>"]
-version = "1.7.1"
+version = "1.8.0"
 
 [deps]
 CategoricalArrays = "324d7699-5711-5eae-9e2f-1d82baa6b597"

--- a/src/resampling.jl
+++ b/src/resampling.jl
@@ -1436,7 +1436,7 @@ function evaluate!(
 
     if !(resampling isa TrainTestPairs)
         error("`resampling` must be an "*
-              "`MLJ.ResamplingStrategy` or tuple of rows "*
+              "`MLJ.ResamplingStrategy` or an vector tuples "*
               "of the form `(train_rows, test_rows)`")
     end
 


### PR DESCRIPTION
For the release notes:

- Allow tuples, in addition to vectors, when specifying `resampling=...` in `evaluate/evaluate!`, and fix a mistake in the error message for invalid `resampling` values (#1010)
