### PR TITLE
Clarify update log message: warm restart is not guaranteed

### DIFF
--- a/src/machines.jl
+++ b/src/machines.jl
@@ -535,7 +535,7 @@ function fitlog(mach, action::Symbol, verbosity)
         put!(MACHINE_CHANNEL, (action, mach))
     elseif verbosity > 0
         action == :train && (@info "Training $mach."; return)
-        action == :update && (@info "Updating $mach."; return)
+        action == :update && (@info "Updating $mach (with warm restart if possible)."; return)
         action == :skip && begin
             @info "Not retraining $mach. Use `force=true` to force."
             return


### PR DESCRIPTION
Closes #1065.

Wording as agreed there. No new action symbol: `:update` covers both the row-change branch and the model-change branch, and "with warm restart if possible" is accurate for both. Adding a separate symbol changes the `MACHINE_CHANNEL` sequences that `@test_mach_sequence` asserts on, which breaks `test/machines.jl:417` among others.
