### PR TITLE
Fix mismatch in performance evaluation displays

### DIFF
--- a/src/resampling/describe.jl
+++ b/src/resampling/describe.jl
@@ -1,3 +1,6 @@
+_compose(μ, σ::Real) = Measurements.measurement(μ, σ)
+_compose(μ, σ) = μ
+
 """
     describe(evaluation::MLJBase.AbstractPerformanceEvaluation)
 
@@ -51,19 +54,9 @@ function DataAPI.describe(e::AbstractPerformanceEvaluation)
         end,
         delim="",
     )
-    ci_strings =
-        map(zip(e.measurement, e.uncertainty_radius_95)) do (measurement, uncertainty)
-            confidence_interval_strings(measurement, uncertainty)
-        end
-    _measurement = first.(ci_strings)
-    _uncertainty_radius_95 = last.(ci_strings)
     for (i, name) in enumerate(measure_names)
-        composite_string = _measurement[i]
-        uncertainty = _uncertainty_radius_95[i]
-        if !isempty(uncertainty)
-            composite_string *= " ± $uncertainty"
-        end 
-        push!(key_value_pairs, Symbol(name) => composite_string)
+        composite = _compose(e.measurement[i], e.uncertainty_radius_95[i])
+        push!(key_value_pairs, Symbol(name) => composite)
     end
     NamedTuple(key_value_pairs)
 end

--- a/src/resampling/describe.jl
+++ b/src/resampling/describe.jl
@@ -51,14 +51,15 @@ function DataAPI.describe(e::AbstractPerformanceEvaluation)
         end,
         delim="",
     )
-    for (i, name) in enumerate(measure_names)
-        value = e.measurement[i]
-        δ =  e.uncertainty_radius_95[i]
-        if !isnothing(δ) && δ isa Real && !isinf(δ)
-            # decorate with uncertainty radius:
-            value = Measurements.measurement(value, δ)
+    ci_strings =
+        map(zip(e.measurement, e.uncertainty_radius_95)) do (measurement, uncertainty)
+            confidence_interval_strings(measurement, uncertainty)
         end
-        push!(key_value_pairs, Symbol(name) => value)
+    _measurement = first.(ci_strings)
+    _uncertainty_radius_95 = last.(ci_strings)
+    for (i, name) in enumerate(measure_names)
+        composite_string = _measurement[i] * " ± " * _uncertainty_radius_95[i]
+        push!(key_value_pairs, Symbol(name) => composite_string)
     end
     NamedTuple(key_value_pairs)
 end

--- a/src/resampling/describe.jl
+++ b/src/resampling/describe.jl
@@ -58,7 +58,11 @@ function DataAPI.describe(e::AbstractPerformanceEvaluation)
     _measurement = first.(ci_strings)
     _uncertainty_radius_95 = last.(ci_strings)
     for (i, name) in enumerate(measure_names)
-        composite_string = _measurement[i] * " ± " * _uncertainty_radius_95[i]
+        composite_string = _measurement[i]
+        uncertainty = _uncertainty_radius_95[i]
+        if !isempty(uncertainty)
+            composite_string *= " ± $uncertainty"
+        end 
         push!(key_value_pairs, Symbol(name) => composite_string)
     end
     NamedTuple(key_value_pairs)

--- a/src/resampling/evaluation_results.jl
+++ b/src/resampling/evaluation_results.jl
@@ -272,7 +272,11 @@ function _summary(e)
             confidence_interval_strings(measurement, uncertainty)
         end
     confidence_intervals = map(ci_strings) do (measurement, uncertainty)
-        measurement * " ± " * uncertainty
+        composite_string = measurement
+        if !empty(uncertainty)
+            composite_string *= " ± " * uncertainty
+        end
+        composite_string
     end
     return "(\"$(e.tag)\", "*join(confidence_intervals, ", ")*")"
 end

--- a/src/resampling/evaluation_results.jl
+++ b/src/resampling/evaluation_results.jl
@@ -167,12 +167,21 @@ round3(x::AbstractFloat) = round(x, sigdigits=3)
 # to address #874, while preserving the display worked out in #757:
 _repr_(f::Function) = repr(f)
 _repr_(x) = repr("text/plain", x)
-_repr(::Nothing) = ""
+_repr_(::Nothing) = ""
 
-function uncertainty_as_string(δ)
-    isnothing(δ) && return ""
-    δ isa Real && isinf(δ) && return ""
-    return string(round3(δ))
+# Return a pair of strings for displaying a measurement with uncertainty, the
+# latter possibly infinite or `nothing`.
+function confidence_interval_strings(measurement, uncertainty)
+    # Measurements.jl automatically displays "a ± b" showing the correct number of
+    # sigdigits, so we leaverage that here. When the uncertainty is `Inf`, we fall back to
+    # 3 sigdigits for `measurement`.
+    measurement isa Real ||
+        return (repr(measurement), "")
+    isnothing(uncertainty) || isinf(uncertainty) &&
+        return (repr(round(measurement, sigdigits=3)), "")
+    composite_string = Measurements.measurement(measurement, uncertainty) |> repr
+    measurement, uncertainty = split(composite_string, " ± ") # strings
+    return (measurement, uncertainty)
 end
 
 # helper for row labels: _label(1) ="A", _label(2) = "B", _label(27) = "BA", etc
@@ -186,9 +195,13 @@ function Base.show(io::IO, ::MIME"text/plain", e::AbstractPerformanceEvaluation)
     )
 
     _measure = [_repr_(m) for m in e.measure]
-    _measurement = round3.(e.measurement)
+    ci_strings =
+        map(zip(e.measurement, e.uncertainty_radius_95)) do (measurement, uncertainty)
+            confidence_interval_strings(measurement, uncertainty)
+        end
+    _measurement = first.(ci_strings)
+    _uncertainty_radius_95 = last.(ci_strings)
     _per_fold = reshape([round3.(v) for v in e.per_fold], length(e.per_fold), 1)
-    _uncertainty_radius_95 = uncertainty_as_string.(e.uncertainty_radius_95)
     show_radius = any(x -> !isempty(x), _uncertainty_radius_95)
     row_labels = _label.(eachindex(e.measure))
 
@@ -254,10 +267,12 @@ function Base.show(io::IO, ::MIME"text/plain", e::AbstractPerformanceEvaluation)
 end
 
 function _summary(e)
-    confidence_intervals = map(zip(e.measurement, e.uncertainty_radius_95)) do (μ, δ)
-        a = round3(μ)
-        b = uncertainty_as_string(δ)
-        isempty(b) ? a : "$a ± $b"
+    ci_strings =
+        map(zip(e.measurement, e.uncertainty_radius_95)) do (measurement, uncertainty)
+            confidence_interval_strings(measurement, uncertainty)
+        end
+    confidence_intervals = map(ci_strings) do (measurement, uncertainty)
+        measurement * " ± " * uncertainty
     end
     return "(\"$(e.tag)\", "*join(confidence_intervals, ", ")*")"
 end
@@ -266,4 +281,3 @@ Base.show(io::IO, e::PerformanceEvaluation) =
     print(io, "PerformanceEvaluation$(_summary(e))")
 Base.show(io::IO, e::CompactPerformanceEvaluation) =
     print(io, "CompactPerformanceEvaluation$(_summary(e))")
-

--- a/src/resampling/evaluation_results.jl
+++ b/src/resampling/evaluation_results.jl
@@ -173,12 +173,14 @@ _repr_(::Nothing) = ""
 # latter possibly infinite or `nothing`.
 function confidence_interval_strings(measurement, uncertainty)
     # Measurements.jl automatically displays "a ± b" showing the correct number of
-    # sigdigits, so we leaverage that here. When the uncertainty is `Inf`, we fall back to
-    # 3 sigdigits for `measurement`.
+    # sigdigits, so we leaverage that here. When the uncertainty is `Inf` or zero, we fall
+    # back to 3 sigdigits for `measurement`.
     measurement isa Real ||
         return (repr(measurement), "")
     isnothing(uncertainty) || isinf(uncertainty) &&
         return (repr(round(measurement, sigdigits=3)), "")
+    iszero(uncertainty) &&
+        return (repr(round(measurement, sigdigits=3)), "0.0")
     composite_string = Measurements.measurement(measurement, uncertainty) |> repr
     measurement, uncertainty = split(composite_string, " ± ") # strings
     return (measurement, uncertainty)
@@ -273,7 +275,7 @@ function _summary(e)
         end
     confidence_intervals = map(ci_strings) do (measurement, uncertainty)
         composite_string = measurement
-        if !empty(uncertainty)
+        if !isempty(uncertainty)
             composite_string *= " ± " * uncertainty
         end
         composite_string

--- a/test/resampling.jl
+++ b/test/resampling.jl
@@ -972,6 +972,13 @@ bogus(yhat, y) = [1,]
 MLJBase._repr_(::API.RobustMeasure{<:typeof(bogus)}) = "bogus"
 
 @testset "more display tests" begin
+    @test MLJBase.confidence_interval_strings(3.1342343, 0.0434) ==
+        (measurement = "3.134", uncertainty = "0.043")
+    @test MLJBase.confidence_interval_strings([1 2; 3 4], :junk) ==
+        (measurement="[1 2; 3 4]", uncertainty="")
+    @test MLJBase.confidence_interval_strings(3.1342343, Inf) ==
+        (measurement = "3.13", uncertainty = "")
+
     # no extra table (only one train-test pair)
     e = evaluate("tag" => model, X, y; resampling=Holdout(),
                  measures = [bogus, log_loss])
@@ -1144,8 +1151,8 @@ end
     # display:
     @test contains(
         sprint(show, es),
-        "[PerformanceEvaluation(\"const\", 0.774 ± 0.0998), "*
-        "PerformanceEvaluation(\"knn\", 0.795 ± 0.0973)]",
+        "[PerformanceEvaluation(\"const\", 0.774 ± 0.1), "*
+        "PerformanceEvaluation(\"knn\", 0.795 ± 0.097)]",
     )
 end
 

--- a/test/resampling.jl
+++ b/test/resampling.jl
@@ -973,11 +973,11 @@ MLJBase._repr_(::API.RobustMeasure{<:typeof(bogus)}) = "bogus"
 
 @testset "more display tests" begin
     @test MLJBase.confidence_interval_strings(3.1342343, 0.0434) ==
-        (measurement = "3.134", uncertainty = "0.043")
+        ("3.134", "0.043")
     @test MLJBase.confidence_interval_strings([1 2; 3 4], :junk) ==
-        (measurement="[1 2; 3 4]", uncertainty="")
+        ("[1 2; 3 4]", "")
     @test MLJBase.confidence_interval_strings(3.1342343, Inf) ==
-        (measurement = "3.13", uncertainty = "")
+        ("3.13", "")
 
     # no extra table (only one train-test pair)
     e = evaluate("tag" => model, X, y; resampling=Holdout(),

--- a/test/resampling.jl
+++ b/test/resampling.jl
@@ -978,6 +978,8 @@ MLJBase._repr_(::API.RobustMeasure{<:typeof(bogus)}) = "bogus"
         ("[1 2; 3 4]", "")
     @test MLJBase.confidence_interval_strings(3.1342343, Inf) ==
         ("3.13", "")
+    @test MLJBase.confidence_interval_strings(3.1342343, 0) ==
+        ("3.13", "0.0")
 
     # no extra table (only one train-test pair)
     e = evaluate("tag" => model, X, y; resampling=Holdout(),


### PR DESCRIPTION
- Resolves #1068. 
- After this PR:

<img width="931" height="500" alt="Screenshot 2026-09-04 at 2 13 10 PM" src="https://github.com/user-attachments/assets/3865951b-7138-4228-b946-0f910e7d1bab" />
